### PR TITLE
feat(WEB-1): Button 공통 컴포넌트 제작

### DIFF
--- a/src/compents/buttons/Button.style.tsx
+++ b/src/compents/buttons/Button.style.tsx
@@ -1,0 +1,56 @@
+import styled from '@emotion/styled';
+import { colors } from '~/styles/colors';
+import { Props } from '~/compents/buttons/Button';
+import { css } from '@emotion/react';
+
+type StyledProps = Omit<Props, 'label'>;
+
+export const Button = styled.button<StyledProps>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  width: ${({ width }) => (width === 'full' ? '100%' : `${width}px`)};
+  height: ${({ height }) => `${height}px`};
+  border: 1px solid ${({ borderType }) => checkBorderType(borderType)};
+  border-radius: ${({ borderType }) => (borderType === 'none' ? 6 : 10)}px;
+  transition: 0.5s;
+
+  ${({ status }) => checkStatusType(status)}
+`;
+
+const checkBorderType = (borderType: Props['borderType']) => {
+  switch (borderType) {
+    case 'primary':
+      return `${colors.Primary500}`;
+    case 'black':
+      return `${colors.Gray500}`;
+    case 'none':
+      return null;
+    default:
+      return null;
+  }
+};
+
+const checkStatusType = (status: Props['status']) => {
+  switch (status) {
+    case 'active':
+      return css`
+        background-color: ${colors.Primary500};
+        color: ${colors.White};
+      `;
+    case 'inactive':
+      return css`
+        background-color: ${colors.White};
+        color: ${colors.Primary500};
+      `;
+    case 'disabled':
+      return css`
+        background-color: ${colors.Primary200};
+        color: ${colors.White};
+      `;
+    default:
+      return '';
+  }
+};

--- a/src/compents/buttons/Button.tsx
+++ b/src/compents/buttons/Button.tsx
@@ -1,0 +1,45 @@
+import * as S from './Button.style';
+import { Combine } from '~/types/utils.type';
+
+export type Props = Combine<
+  {
+    status: 'active' | 'inactive' | 'disabled';
+    borderType?: 'primary' | 'black' | 'none';
+    label: string;
+    width?: number | 'full';
+    height?: number;
+    onClick: () => void;
+    hasBorder?: boolean;
+    children?: React.ReactNode;
+  },
+  React.ComponentProps<'button'>
+>;
+
+const Button = ({
+  status,
+  label,
+  width = 'full',
+  height = 40,
+  onClick,
+  hasBorder = false,
+  borderType = 'primary',
+  children,
+  ...props
+}: Props) => {
+  return (
+    <S.Button
+      type={'button'}
+      hasBorder={hasBorder}
+      onClick={onClick}
+      status={status}
+      width={width}
+      height={height}
+      borderType={borderType}
+      {...props}>
+      <span>{label}</span>
+      {children}
+    </S.Button>
+  );
+};
+
+export default Button;

--- a/src/hooks/useSingleSelect.tsx
+++ b/src/hooks/useSingleSelect.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+export function useSingleSelection<T>() {
+  const [selectedValue, setSelectedValue] = useState<T | null>(null);
+
+  const select = (value: T) => () => {
+    setSelectedValue(value);
+  };
+
+  const checkSelectedValue = (value: T) => {
+    return selectedValue === value;
+  };
+
+  return { selectedValue, select, checkSelectedValue };
+}

--- a/src/hooks/useToggleSelect.tsx
+++ b/src/hooks/useToggleSelect.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+export function useToggleSelect<T>() {
+  const [selectedValues, setSelectedValues] = useState<T[]>([]);
+
+  const select = (value: T) => () => {
+    if (selectedValues.includes(value)) {
+      return setSelectedValues(selectedValues.filter(v => v !== value));
+    }
+    setSelectedValues([...selectedValues, value]);
+  };
+
+  const checkSelectedValues = (value: T) => {
+    return selectedValues.includes(value);
+  };
+
+  return { selectedValues, select, checkSelectedValues };
+}


### PR DESCRIPTION
### Button 컴포넌트 제작

## 개요
- Button 공통 컴포넌트를 제작했습니다.
![2024-02-03_10-56-05](https://github.com/uoslife/client-meeting-season4/assets/89263598/78223d2d-89d0-47a6-be55-eff12a4550e8)

- Button 공통 컴포넌트에 사용될 로직을 외부에서 쉽게 처리할 수 있게끔 커스텀 훅으로 만들었습니다.

## 상세설명
**Button 컴포넌트를 받는 props에서 기본적으로 필요한 것들에 대해 설명하자면...**
- status : 버튼을 클릭했을 때, 안 했을 떄와 같은 버튼 상태를 나타냅니다.
- borderType : 버튼의 border 상태를 나타냅니다.
- label : 버튼 내부 문구입니다.
- onClcik : 외부에서 컴포넌트 상태 관리를 할 수 있게 했습니다.

Combine은 무엇인가요? 
- ButtonProps는 Button 컴포넌트가 받을 수 있는 prop들의 타입을 정의합니다. Combine이라는 유틸리티 타입을 사용하여 두 개의 타입을 합치는데, 첫 번째는 Button 컴포넌트가 직접 정의한 prop들을 나타내고, 두 번째는 기본 HTML button 요소가 받을 수 있는 prop들을 나타냅니다. Combine 타입은 두 개의 타입을 합치되, 첫 번째 타입에서 이미 정의된 prop들은 두 번째 타입에서 제외합니다.
**_쉽게 말해서, button의 HTML엘리먼트와 Button props가 겹친다면 Button props를 우선시 하겠다 라는 말입니다._** 

## 참고 자료
- https://evan-moon.github.io/2020/11/28/making-your-components-extensible-with-typescript/