### PR TITLE
fix(WEB-30): atom 구조 변경

### DIFF
--- a/src/hooks/useGroupEntireValue.ts
+++ b/src/hooks/useGroupEntireValue.ts
@@ -1,0 +1,26 @@
+import { atom, useAtomValue } from 'jotai';
+import { useMemo } from 'react';
+import { GroupState, groupApplyAtoms } from '~/store/meeting';
+
+const useGroupEntireValue = () => {
+  return useAtomValue(
+    useMemo(
+      () => ({
+        ...atom(get => {
+          const groupInfo = {} as GroupState;
+          Object.entries(groupApplyAtoms).map(([key, value]) => {
+            Object.assign(groupInfo, {
+              [key]: get<unknown>(value),
+            });
+          });
+
+          return groupInfo;
+        }),
+        debugLabel: 'groupEntireInfo',
+      }),
+      [],
+    ),
+  );
+};
+
+export default useGroupEntireValue;

--- a/src/hooks/useGroupEntireValue.ts
+++ b/src/hooks/useGroupEntireValue.ts
@@ -1,13 +1,13 @@
 import { atom, useAtomValue } from 'jotai';
 import { useMemo } from 'react';
-import { groupApplyAtoms } from '~/store/meeting';
+import { GroupApplyInfo, groupApplyAtoms } from '~/store/meeting';
 
 const useGroupEntireValue = () => {
   return useAtomValue(
     useMemo(
       () => ({
         ...atom(get => {
-          const groupInfo = {} as typeof groupApplyAtoms;
+          const groupInfo = {} as GroupApplyInfo;
           Object.entries(groupApplyAtoms).map(([key, value]) => {
             Object.assign(groupInfo, {
               [key]: get<unknown>(value),

--- a/src/hooks/useGroupEntireValue.ts
+++ b/src/hooks/useGroupEntireValue.ts
@@ -1,13 +1,13 @@
 import { atom, useAtomValue } from 'jotai';
 import { useMemo } from 'react';
-import { GroupState, groupApplyAtoms } from '~/store/meeting';
+import { groupApplyAtoms } from '~/store/meeting';
 
 const useGroupEntireValue = () => {
   return useAtomValue(
     useMemo(
       () => ({
         ...atom(get => {
-          const groupInfo = {} as GroupState;
+          const groupInfo = {} as typeof groupApplyAtoms;
           Object.entries(groupApplyAtoms).map(([key, value]) => {
             Object.assign(groupInfo, {
               [key]: get<unknown>(value),

--- a/src/hooks/usePersonalEntireValue.ts
+++ b/src/hooks/usePersonalEntireValue.ts
@@ -1,13 +1,13 @@
 import { atom, useAtomValue } from 'jotai';
 import { useMemo } from 'react';
-import { personalApplyAtoms } from '~/store/meeting';
+import { PersonalApplyInfo, personalApplyAtoms } from '~/store/meeting';
 
 const usePersonalEntireValue = () => {
   return useAtomValue(
     useMemo(
       () => ({
         ...atom(get => {
-          const personalInfo = {} as typeof personalApplyAtoms;
+          const personalInfo = {} as PersonalApplyInfo;
           Object.entries(personalApplyAtoms).map(([key, value]) => {
             Object.assign(personalInfo, {
               [key]: get<unknown>(value),

--- a/src/hooks/usePersonalEntireValue.ts
+++ b/src/hooks/usePersonalEntireValue.ts
@@ -1,13 +1,13 @@
 import { atom, useAtomValue } from 'jotai';
 import { useMemo } from 'react';
-import { PersonalState, personalApplyAtoms } from '~/store/meeting';
+import { personalApplyAtoms } from '~/store/meeting';
 
 const usePersonalEntireValue = () => {
   return useAtomValue(
     useMemo(
       () => ({
         ...atom(get => {
-          const personalInfo = {} as PersonalState;
+          const personalInfo = {} as typeof personalApplyAtoms;
           Object.entries(personalApplyAtoms).map(([key, value]) => {
             Object.assign(personalInfo, {
               [key]: get<unknown>(value),

--- a/src/hooks/usePersonalEntireValue.ts
+++ b/src/hooks/usePersonalEntireValue.ts
@@ -1,0 +1,26 @@
+import { atom, useAtomValue } from 'jotai';
+import { useMemo } from 'react';
+import { PersonalState, personalApplyAtoms } from '~/store/meeting';
+
+const usePersonalEntireValue = () => {
+  return useAtomValue(
+    useMemo(
+      () => ({
+        ...atom(get => {
+          const personalInfo = {} as PersonalState;
+          Object.entries(personalApplyAtoms).map(([key, value]) => {
+            Object.assign(personalInfo, {
+              [key]: get<unknown>(value),
+            });
+          });
+
+          return personalInfo;
+        }),
+        debugLabel: 'personalEntireInfo',
+      }),
+      [],
+    ),
+  );
+};
+
+export default usePersonalEntireValue;

--- a/src/store/meeting/common.ts
+++ b/src/store/meeting/common.ts
@@ -6,17 +6,21 @@ meetingTypeAtom.debugLabel = 'meetingTypeAtom';
 export const univTypeAtom = atom<'HUFS' | 'KHU' | 'UOS' | null>(null);
 univTypeAtom.debugLabel = 'univTypeAtom';
 
-export type CommonState = {
-  info_nickname: PrimitiveAtom<string>;
-  info_gender: PrimitiveAtom<string>;
-  info_age: PrimitiveAtom<number>;
-  info_height: PrimitiveAtom<number>;
-  info_kakaoId: PrimitiveAtom<string>;
-  info_major: PrimitiveAtom<string>;
-  info_studentType: PrimitiveAtom<string>;
+export type CommonApplyInfo = {
+  info_nickname: string;
+  info_gender: string;
+  info_age: number;
+  info_height: number;
+  info_kakaoId: string;
+  info_major: string;
+  info_studentType: string;
 };
 
-export const commonAtoms: CommonState = {
+export type CommonApplyAtoms = {
+  [key in keyof CommonApplyInfo]: PrimitiveAtom<CommonApplyInfo[key]>;
+};
+
+export const commonApplyAtoms: CommonApplyAtoms = {
   info_nickname: atom(''),
   info_gender: atom(''),
   info_age: atom(0),

--- a/src/store/meeting/common.ts
+++ b/src/store/meeting/common.ts
@@ -1,4 +1,5 @@
 import { atom } from 'jotai';
+import { PrimitiveAtom } from 'jotai/vanilla';
 
 export const meetingTypeAtom = atom<'group' | 'personal' | null>(null);
 meetingTypeAtom.debugLabel = 'meetingTypeAtom';
@@ -6,21 +7,21 @@ export const univTypeAtom = atom<'HUFS' | 'KHU' | 'UOS' | null>(null);
 univTypeAtom.debugLabel = 'univTypeAtom';
 
 export type CommonState = {
-  info_nickname: string;
-  info_gender: string;
-  info_age: number;
-  info_height: number;
-  info_kakaoId: string;
-  info_major: string;
-  info_studentType: string;
+  info_nickname: PrimitiveAtom<string>;
+  info_gender: PrimitiveAtom<string>;
+  info_age: PrimitiveAtom<number>;
+  info_height: PrimitiveAtom<number>;
+  info_kakaoId: PrimitiveAtom<string>;
+  info_major: PrimitiveAtom<string>;
+  info_studentType: PrimitiveAtom<string>;
 };
 
-export const initialCommonState: CommonState = {
-  info_nickname: '',
-  info_gender: '',
-  info_age: 0,
-  info_height: 0,
-  info_kakaoId: '',
-  info_major: '',
-  info_studentType: '',
+export const commonAtoms: CommonState = {
+  info_nickname: atom(''),
+  info_gender: atom(''),
+  info_age: atom(0),
+  info_height: atom(0),
+  info_kakaoId: atom(''),
+  info_major: atom(''),
+  info_studentType: atom(''),
 };

--- a/src/store/meeting/common.ts
+++ b/src/store/meeting/common.ts
@@ -1,5 +1,4 @@
 import { atom } from 'jotai';
-import { ApplyData } from '~/types/apply.type';
 
 export const meetingTypeAtom = atom<'group' | 'personal' | null>(null);
 meetingTypeAtom.debugLabel = 'meetingTypeAtom';
@@ -7,56 +6,21 @@ export const univTypeAtom = atom<'HUFS' | 'KHU' | 'UOS' | null>(null);
 univTypeAtom.debugLabel = 'univTypeAtom';
 
 export type CommonState = {
-  info_nickname: ApplyData<string>;
-  info_gender: ApplyData<string>;
-  info_age: ApplyData<number>;
-  info_height: ApplyData<number>;
-  info_kakaoId: ApplyData<string>;
-  info_major: ApplyData<string>;
-  info_studentType: ApplyData<string>;
+  info_nickname: string;
+  info_gender: string;
+  info_age: number;
+  info_height: number;
+  info_kakaoId: string;
+  info_major: string;
+  info_studentType: string;
 };
 
 export const initialCommonState: CommonState = {
-  info_nickname: {
-    title_kr: '닉네임',
-    title_en: 'nickname',
-    type: 'info',
-    data: '',
-  },
-  info_gender: {
-    title_kr: '성별',
-    title_en: 'gender',
-    type: 'info',
-    data: '',
-  },
-  info_age: {
-    title_kr: '나이',
-    title_en: 'age',
-    type: 'info',
-    data: 0,
-  },
-  info_height: {
-    title_kr: '키',
-    title_en: 'height',
-    type: 'info',
-    data: 0,
-  },
-  info_kakaoId: {
-    title_kr: '카카오톡 ID',
-    title_en: 'kakaoId',
-    type: 'info',
-    data: '',
-  },
-  info_major: {
-    title_kr: '학과',
-    title_en: 'major',
-    type: 'info',
-    data: '',
-  },
-  info_studentType: {
-    title_kr: '신분',
-    title_en: 'studentType',
-    type: 'info',
-    data: '',
-  },
+  info_nickname: '',
+  info_gender: '',
+  info_age: 0,
+  info_height: 0,
+  info_kakaoId: '',
+  info_major: '',
+  info_studentType: '',
 };

--- a/src/store/meeting/group.ts
+++ b/src/store/meeting/group.ts
@@ -1,48 +1,29 @@
 import { ApplyQuestionArrType } from '~/types/apply.type';
-import { atom } from 'jotai';
-import { CommonState, initialCommonState } from '~/store/meeting/common';
+import { PrimitiveAtom, atom } from 'jotai';
+import { CommonState, commonAtoms } from '~/store/meeting/common';
 
-export type GroupState = {
-  code: string;
-  info_name: string;
-  info_preferDay: string[];
-  info_question: ApplyQuestionArrType;
-  prefer_age: string[];
-  prefer_major: string[];
-  prefer_atmosphere: string;
+export type GroupAtoms = {
+  code: PrimitiveAtom<string>;
+  info_name: PrimitiveAtom<string>;
+  info_preferDay: PrimitiveAtom<string[]>;
+  info_question: PrimitiveAtom<ApplyQuestionArrType>;
+  prefer_age: PrimitiveAtom<string[]>;
+  prefer_major: PrimitiveAtom<string[]>;
+  prefer_atmosphere: PrimitiveAtom<string>;
 } & CommonState;
 
-const initialGroupState: GroupState = {
-  ...initialCommonState,
-  code: '',
-  info_name: '',
-  info_preferDay: [''],
-  info_question: [
+export const groupApplyAtoms = {
+  ...commonAtoms,
+  code: atom(''),
+  info_name: atom(''),
+  info_preferDay: atom(['']),
+  info_question: atom([
     { label: '', order: 0 },
     { label: '', order: 1 },
     { label: '', order: 2 },
     { label: '', order: 3 },
-  ],
-  prefer_age: [''],
-  prefer_major: [''],
-  prefer_atmosphere: '',
+  ]),
+  prefer_age: atom(['']),
+  prefer_major: atom(['']),
+  prefer_atmosphere: atom(''),
 };
-
-export type GroupItemName = keyof GroupState;
-
-type GroupApplyAtoms = {
-  [key in GroupItemName]: ReturnType<typeof atom<GroupState[key]>>;
-};
-
-export const groupApplyAtoms = (() => {
-  const state = {} as GroupApplyAtoms;
-  (Object.keys(initialGroupState) as GroupItemName[]).map(key => {
-    Object.assign(state, {
-      [key]: {
-        ...atom<GroupState[typeof key]>(initialGroupState[key]),
-        debugLabel: key,
-      },
-    });
-  });
-  return state;
-})();

--- a/src/store/meeting/group.ts
+++ b/src/store/meeting/group.ts
@@ -1,19 +1,23 @@
 import { ApplyQuestionArrType } from '~/types/apply.type';
-import { PrimitiveAtom, atom } from 'jotai';
-import { CommonState, commonAtoms } from '~/store/meeting/common';
+import { atom } from 'jotai';
+import { CommonApplyAtoms, commonApplyAtoms } from '.';
 
-export type GroupAtoms = {
-  code: PrimitiveAtom<string>;
-  info_name: PrimitiveAtom<string>;
-  info_preferDay: PrimitiveAtom<string[]>;
-  info_question: PrimitiveAtom<ApplyQuestionArrType>;
-  prefer_age: PrimitiveAtom<string[]>;
-  prefer_major: PrimitiveAtom<string[]>;
-  prefer_atmosphere: PrimitiveAtom<string>;
-} & CommonState;
+export type GroupApplyInfo = {
+  code: string;
+  info_name: string;
+  info_preferDay: string[];
+  info_question: ApplyQuestionArrType;
+  prefer_age: string[];
+  prefer_major: string[];
+  prefer_atmosphere: string;
+};
+
+export type GroupApplyAtoms = {
+  [key in keyof GroupApplyInfo]: ReturnType<typeof atom<GroupApplyInfo[key]>>;
+} & CommonApplyAtoms;
 
 export const groupApplyAtoms = {
-  ...commonAtoms,
+  ...commonApplyAtoms,
   code: atom(''),
   info_name: atom(''),
   info_preferDay: atom(['']),
@@ -27,3 +31,7 @@ export const groupApplyAtoms = {
   prefer_major: atom(['']),
   prefer_atmosphere: atom(''),
 };
+
+for (const key in groupApplyAtoms) {
+  groupApplyAtoms[key as keyof GroupApplyAtoms].debugLabel = key;
+}

--- a/src/store/meeting/group.ts
+++ b/src/store/meeting/group.ts
@@ -1,61 +1,31 @@
-import { ApplyData, ApplyQuestionArrType } from '~/types/apply.type';
+import { ApplyQuestionArrType } from '~/types/apply.type';
 import { atom } from 'jotai';
 import { CommonState, initialCommonState } from '~/store/meeting/common';
 
 export type GroupState = {
   code: string;
-  info_name: ApplyData<string>;
-  info_preferDay: ApplyData<string[]>;
-  info_question: ApplyData<ApplyQuestionArrType>;
-  prefer_age: ApplyData<string[]>;
-  prefer_major: ApplyData<string[]>;
-  prefer_atmosphere: ApplyData<string>;
+  info_name: string;
+  info_preferDay: string[];
+  info_question: ApplyQuestionArrType;
+  prefer_age: string[];
+  prefer_major: string[];
+  prefer_atmosphere: string;
 } & CommonState;
 
 const initialGroupState: GroupState = {
   ...initialCommonState,
   code: '',
-  info_name: {
-    title_kr: '팅 이름',
-    title_en: 'name',
-    type: 'info',
-    data: '',
-  },
-  info_preferDay: {
-    title_kr: '선호요일',
-    title_en: 'preferDay',
-    type: 'info',
-    data: [''],
-  },
-  info_question: {
-    title_kr: 'Q&A',
-    title_en: 'question',
-    type: 'info',
-    data: [
-      { label: '', order: 0 },
-      { label: '', order: 1 },
-      { label: '', order: 2 },
-      { label: '', order: 3 },
-    ],
-  },
-  prefer_age: {
-    title_kr: '나이',
-    title_en: 'age',
-    type: 'prefer',
-    data: [''],
-  },
-  prefer_major: {
-    title_kr: '대학',
-    title_en: 'univ',
-    type: 'prefer',
-    data: [''],
-  },
-  prefer_atmosphere: {
-    title_kr: '분위기',
-    title_en: 'atmosphere',
-    type: 'prefer',
-    data: '',
-  },
+  info_name: '',
+  info_preferDay: [''],
+  info_question: [
+    { label: '', order: 0 },
+    { label: '', order: 1 },
+    { label: '', order: 2 },
+    { label: '', order: 3 },
+  ],
+  prefer_age: [''],
+  prefer_major: [''],
+  prefer_atmosphere: '',
 };
 
 export type GroupItemName = keyof GroupState;

--- a/src/store/meeting/group.ts
+++ b/src/store/meeting/group.ts
@@ -1,6 +1,6 @@
 import { ApplyData, ApplyQuestionArrType } from '~/types/apply.type';
 import { atom } from 'jotai';
-import { initialCommonState } from '~/store/meeting/common';
+import { CommonState, initialCommonState } from '~/store/meeting/common';
 
 export type GroupState = {
   code: string;
@@ -10,9 +10,9 @@ export type GroupState = {
   prefer_age: ApplyData<string[]>;
   prefer_major: ApplyData<string[]>;
   prefer_atmosphere: ApplyData<string>;
-};
+} & CommonState;
 
-const initialState: GroupState = {
+const initialGroupState: GroupState = {
   ...initialCommonState,
   code: '',
   info_name: {
@@ -58,5 +58,21 @@ const initialState: GroupState = {
   },
 };
 
-export const groupApplyAtom = atom<GroupState>(initialState);
-groupApplyAtom.debugLabel = 'groupApplyAtom';
+export type GroupItemName = keyof GroupState;
+
+type GroupApplyAtoms = {
+  [key in GroupItemName]: ReturnType<typeof atom<GroupState[key]>>;
+};
+
+export const groupApplyAtoms = (() => {
+  const state = {} as GroupApplyAtoms;
+  (Object.keys(initialGroupState) as GroupItemName[]).map(key => {
+    Object.assign(state, {
+      [key]: {
+        ...atom<GroupState[typeof key]>(initialGroupState[key]),
+        debugLabel: key,
+      },
+    });
+  });
+  return state;
+})();

--- a/src/store/meeting/personal.ts
+++ b/src/store/meeting/personal.ts
@@ -1,6 +1,6 @@
 import { ApplyData, ApplyQuestionArrType } from '~/types/apply.type';
 import { atom } from 'jotai';
-import { initialCommonState } from '~/store/meeting/common';
+import { CommonState, initialCommonState } from '~/store/meeting/common';
 
 export type PersonalState = {
   info_drink: ApplyData<string[]>;
@@ -19,9 +19,9 @@ export type PersonalState = {
   prefer_smoking: ApplyData<string>;
   prefer_animal: ApplyData<string[]>;
   prefer_mbti: ApplyData<string[]>;
-};
+} & CommonState;
 
-const initialState: PersonalState = {
+const initialPersonalState: PersonalState = {
   ...initialCommonState,
   info_religion: {
     title_kr: '종교',
@@ -127,5 +127,23 @@ const initialState: PersonalState = {
   },
 };
 
-export const personalApplyAtom = atom<PersonalState>(initialState);
-personalApplyAtom.debugLabel = 'personalApplyAtom';
+export type PersonalItemName = keyof PersonalState;
+
+type PersonalApplyAtoms = {
+  [key in PersonalItemName]: ReturnType<typeof atom<PersonalState[key]>>;
+};
+
+export const personalApplyAtoms = (() => {
+  const state = {} as PersonalApplyAtoms;
+  (
+    Object.keys(initialPersonalState) as (keyof typeof initialPersonalState)[]
+  ).map(key => {
+    Object.assign(state, {
+      [key]: {
+        ...atom<PersonalState[typeof key]>(initialPersonalState[key]),
+        debugLabel: key,
+      },
+    });
+  });
+  return state;
+})();

--- a/src/store/meeting/personal.ts
+++ b/src/store/meeting/personal.ts
@@ -1,130 +1,50 @@
-import { ApplyData, ApplyQuestionArrType } from '~/types/apply.type';
+import { ApplyQuestionArrType } from '~/types/apply.type';
 import { atom } from 'jotai';
 import { CommonState, initialCommonState } from '~/store/meeting/common';
 
 export type PersonalState = {
-  info_drink: ApplyData<string[]>;
-  info_religion: ApplyData<string>;
-  info_smoking: ApplyData<string>;
-  info_animal: ApplyData<string[]>;
-  info_mbti: ApplyData<string[]>;
-  info_interests: ApplyData<string[]>;
-  info_question: ApplyData<ApplyQuestionArrType>;
-  prefer_age: ApplyData<string[]>;
-  prefer_height: ApplyData<string[]>;
-  prefer_studentType: ApplyData<string[]>;
-  prefer_univ: ApplyData<string[]>;
-  prefer_drink: ApplyData<string[]>;
-  prefer_religion: ApplyData<string>;
-  prefer_smoking: ApplyData<string>;
-  prefer_animal: ApplyData<string[]>;
-  prefer_mbti: ApplyData<string[]>;
+  info_drink: string[];
+  info_religion: string;
+  info_smoking: string;
+  info_animal: string[];
+  info_mbti: string[];
+  info_interests: string[];
+  info_question: ApplyQuestionArrType;
+  prefer_age: string[];
+  prefer_height: string[];
+  prefer_studentType: string[];
+  prefer_univ: string[];
+  prefer_drink: string[];
+  prefer_religion: string;
+  prefer_smoking: string;
+  prefer_animal: string[];
+  prefer_mbti: string[];
 } & CommonState;
 
 const initialPersonalState: PersonalState = {
   ...initialCommonState,
-  info_religion: {
-    title_kr: '종교',
-    title_en: 'religion',
-    type: 'info',
-    data: '',
-  },
-  info_smoking: {
-    title_kr: '흡연',
-    title_en: 'smoking',
-    type: 'info',
-    data: '',
-  },
-  info_drink: {
-    title_kr: '음주 횟수',
-    title_en: 'drink',
-    type: 'info',
-    data: [''],
-  },
-  info_animal: {
-    title_kr: '동물상',
-    title_en: 'animal',
-    type: 'info',
-    data: [''],
-  },
-  info_mbti: {
-    title_kr: 'MBTI',
-    title_en: 'mbti',
-    type: 'info',
-    data: ['', '', '', ''],
-  },
-  info_interests: {
-    title_kr: '관심사',
-    title_en: 'interests',
-    type: 'info',
-    data: [''],
-  },
-  info_question: {
-    title_kr: 'Q&A',
-    title_en: 'question',
-    type: 'info',
-    data: [
-      { label: '', order: 0 },
-      { label: '', order: 1 },
-      { label: '', order: 2 },
-      { label: '', order: 3 },
-      { label: '', order: 4 },
-    ],
-  },
-  prefer_age: {
-    title_kr: '나이',
-    title_en: 'age',
-    type: 'prefer',
-    data: [''],
-  },
-  prefer_height: {
-    title_kr: '키',
-    title_en: 'height',
-    type: 'prefer',
-    data: [''],
-  },
-  prefer_studentType: {
-    title_kr: '신분',
-    title_en: 'studentType',
-    type: 'prefer',
-    data: [''],
-  },
-  prefer_univ: {
-    title_kr: '선호 대학',
-    title_en: 'univ',
-    type: 'prefer',
-    data: [''],
-  },
-  prefer_smoking: {
-    title_kr: '흡연 여부',
-    title_en: 'smoking',
-    type: 'prefer',
-    data: '',
-  },
-  prefer_religion: {
-    title_kr: '선호 종교',
-    title_en: 'religion',
-    type: 'prefer',
-    data: '',
-  },
-  prefer_drink: {
-    title_kr: '음주 횟수',
-    title_en: 'drink',
-    type: 'prefer',
-    data: [''],
-  },
-  prefer_animal: {
-    title_kr: '동물상',
-    title_en: 'animal',
-    type: 'prefer',
-    data: [''],
-  },
-  prefer_mbti: {
-    title_kr: 'MBTI',
-    title_en: 'mbti',
-    type: 'prefer',
-    data: [''],
-  },
+  info_religion: '',
+  info_smoking: '',
+  info_drink: [''],
+  info_animal: [''],
+  info_mbti: ['', '', '', ''],
+  info_interests: [''],
+  info_question: [
+    { label: '', order: 0 },
+    { label: '', order: 1 },
+    { label: '', order: 2 },
+    { label: '', order: 3 },
+    { label: '', order: 4 },
+  ],
+  prefer_age: [''],
+  prefer_height: [''],
+  prefer_studentType: [''],
+  prefer_univ: [''],
+  prefer_smoking: '',
+  prefer_religion: '',
+  prefer_drink: [''],
+  prefer_animal: [''],
+  prefer_mbti: [''],
 };
 
 export type PersonalItemName = keyof PersonalState;

--- a/src/store/meeting/personal.ts
+++ b/src/store/meeting/personal.ts
@@ -1,28 +1,34 @@
 import { ApplyQuestionArrType } from '~/types/apply.type';
-import { PrimitiveAtom, atom } from 'jotai';
-import { CommonState, commonAtoms } from '~/store/meeting/common';
+import { atom } from 'jotai';
+import { CommonApplyAtoms, commonApplyAtoms } from '.';
+
+export type PersonalApplyInfo = {
+  info_drink: string[];
+  info_religion: string;
+  info_smoking: string;
+  info_animal: string[];
+  info_mbti: string[];
+  info_interests: string[];
+  info_question: ApplyQuestionArrType;
+  prefer_age: string[];
+  prefer_height: string[];
+  prefer_studentType: string[];
+  prefer_univ: string[];
+  prefer_drink: string[];
+  prefer_religion: string;
+  prefer_smoking: string;
+  prefer_animal: string[];
+  prefer_mbti: string[];
+};
 
 export type PesronalApplyAtoms = {
-  info_drink: PrimitiveAtom<string[]>;
-  info_religion: PrimitiveAtom<string>;
-  info_smoking: PrimitiveAtom<string>;
-  info_animal: PrimitiveAtom<string[]>;
-  info_mbti: PrimitiveAtom<string[]>;
-  info_interests: PrimitiveAtom<string[]>;
-  info_question: PrimitiveAtom<ApplyQuestionArrType>;
-  prefer_age: PrimitiveAtom<string[]>;
-  prefer_height: PrimitiveAtom<string[]>;
-  prefer_studentType: PrimitiveAtom<string[]>;
-  prefer_univ: PrimitiveAtom<string[]>;
-  prefer_drink: PrimitiveAtom<string[]>;
-  prefer_religion: PrimitiveAtom<string>;
-  prefer_smoking: PrimitiveAtom<string>;
-  prefer_animal: PrimitiveAtom<string[]>;
-  prefer_mbti: PrimitiveAtom<string[]>;
-} & CommonState;
+  [key in keyof PersonalApplyInfo]: ReturnType<
+    typeof atom<PersonalApplyInfo[key]>
+  >;
+} & CommonApplyAtoms;
 
 export const personalApplyAtoms: PesronalApplyAtoms = {
-  ...commonAtoms,
+  ...commonApplyAtoms,
   info_religion: atom(''),
   info_smoking: atom(''),
   info_drink: atom(['']),
@@ -46,3 +52,7 @@ export const personalApplyAtoms: PesronalApplyAtoms = {
   prefer_animal: atom(['']),
   prefer_mbti: atom(['']),
 };
+
+for (const key in personalApplyAtoms) {
+  personalApplyAtoms[key as keyof PesronalApplyAtoms].debugLabel = key;
+}

--- a/src/store/meeting/personal.ts
+++ b/src/store/meeting/personal.ts
@@ -1,69 +1,48 @@
 import { ApplyQuestionArrType } from '~/types/apply.type';
-import { atom } from 'jotai';
-import { CommonState, initialCommonState } from '~/store/meeting/common';
+import { PrimitiveAtom, atom } from 'jotai';
+import { CommonState, commonAtoms } from '~/store/meeting/common';
 
-export type PersonalState = {
-  info_drink: string[];
-  info_religion: string;
-  info_smoking: string;
-  info_animal: string[];
-  info_mbti: string[];
-  info_interests: string[];
-  info_question: ApplyQuestionArrType;
-  prefer_age: string[];
-  prefer_height: string[];
-  prefer_studentType: string[];
-  prefer_univ: string[];
-  prefer_drink: string[];
-  prefer_religion: string;
-  prefer_smoking: string;
-  prefer_animal: string[];
-  prefer_mbti: string[];
+export type PesronalApplyAtoms = {
+  info_drink: PrimitiveAtom<string[]>;
+  info_religion: PrimitiveAtom<string>;
+  info_smoking: PrimitiveAtom<string>;
+  info_animal: PrimitiveAtom<string[]>;
+  info_mbti: PrimitiveAtom<string[]>;
+  info_interests: PrimitiveAtom<string[]>;
+  info_question: PrimitiveAtom<ApplyQuestionArrType>;
+  prefer_age: PrimitiveAtom<string[]>;
+  prefer_height: PrimitiveAtom<string[]>;
+  prefer_studentType: PrimitiveAtom<string[]>;
+  prefer_univ: PrimitiveAtom<string[]>;
+  prefer_drink: PrimitiveAtom<string[]>;
+  prefer_religion: PrimitiveAtom<string>;
+  prefer_smoking: PrimitiveAtom<string>;
+  prefer_animal: PrimitiveAtom<string[]>;
+  prefer_mbti: PrimitiveAtom<string[]>;
 } & CommonState;
 
-const initialPersonalState: PersonalState = {
-  ...initialCommonState,
-  info_religion: '',
-  info_smoking: '',
-  info_drink: [''],
-  info_animal: [''],
-  info_mbti: ['', '', '', ''],
-  info_interests: [''],
-  info_question: [
+export const personalApplyAtoms: PesronalApplyAtoms = {
+  ...commonAtoms,
+  info_religion: atom(''),
+  info_smoking: atom(''),
+  info_drink: atom(['']),
+  info_animal: atom(['']),
+  info_mbti: atom(['', '', '', '']),
+  info_interests: atom(['']),
+  info_question: atom([
     { label: '', order: 0 },
     { label: '', order: 1 },
     { label: '', order: 2 },
     { label: '', order: 3 },
     { label: '', order: 4 },
-  ],
-  prefer_age: [''],
-  prefer_height: [''],
-  prefer_studentType: [''],
-  prefer_univ: [''],
-  prefer_smoking: '',
-  prefer_religion: '',
-  prefer_drink: [''],
-  prefer_animal: [''],
-  prefer_mbti: [''],
+  ]),
+  prefer_age: atom(['']),
+  prefer_height: atom(['']),
+  prefer_studentType: atom(['']),
+  prefer_univ: atom(['']),
+  prefer_smoking: atom(''),
+  prefer_religion: atom(''),
+  prefer_drink: atom(['']),
+  prefer_animal: atom(['']),
+  prefer_mbti: atom(['']),
 };
-
-export type PersonalItemName = keyof PersonalState;
-
-type PersonalApplyAtoms = {
-  [key in PersonalItemName]: ReturnType<typeof atom<PersonalState[key]>>;
-};
-
-export const personalApplyAtoms = (() => {
-  const state = {} as PersonalApplyAtoms;
-  (
-    Object.keys(initialPersonalState) as (keyof typeof initialPersonalState)[]
-  ).map(key => {
-    Object.assign(state, {
-      [key]: {
-        ...atom<PersonalState[typeof key]>(initialPersonalState[key]),
-        debugLabel: key,
-      },
-    });
-  });
-  return state;
-})();

--- a/src/types/apply.type.ts
+++ b/src/types/apply.type.ts
@@ -1,12 +1,1 @@
 export type ApplyQuestionArrType = Array<{ label: string; order: number }>;
-
-export type ApplyDataType = number | string | string[] | ApplyQuestionArrType;
-
-export type ApplyData<T extends ApplyDataType> = {
-  title_kr: string;
-  title_en: string;
-  type: 'info' | 'prefer';
-  data: T;
-};
-
-export type ApplyDataArr = Array<ApplyData<ApplyDataType>>;


### PR DESCRIPTION
# Summary

- meeting atom(personalApplyAtom, groupApplyAtom)의 구조를 변경하였습니다. 코드 가독성 / 직관성의 개선과 Jotai DevTool 사용을 더 편하게 하기 위함입니다.

# 구조 설명

- ApplyData라고 하는, Wrapper 타입을 제거했습니다.
- 단일 atom이 하나의 큰 객체를 관리하던 것을, 객체의 각 entry들이 개별 atom을 관리하는 것으로 바꿨습니다. 이제 몇몇 item을 제외하고는 useImmerAtom을 쓰지 않아도 깔끔한 코드 작성이 가능합니다.

## Before
![image](https://github.com/uoslife/client-meeting-season4/assets/97388599/82115547-1e30-44f8-9489-a9ad706d7756)

## After
![image](https://github.com/uoslife/client-meeting-season4/assets/97388599/8e35d7a5-df5b-4b7d-89b8-f8ce583c15a6)

# Usage

## Before

```ts
import { groupApplyAtom } from '~/store/meeting';
import { useImmerAtom } from 'jotai-immer';

() => {
  const [nickname, setNickname] = useImmerAtom(groupApplyAtom);
  const handleSetNickname = () => {
    setNickname(draft => {
      draft.info_name.data = '김영찬123';
    });
  };
}
```

## After

```ts
import { groupApplyAtoms } from '~/store/meeting';
import { useAtom } from 'jotai';

() => {
  const [nickname, setNickname] = useAtom(groupApplyAtoms.info_nickname);
  const handleSetNickname = () => {
    setNickname('김영찬123'});
  };
}
```