### PR TITLE
feat[WEB-35]: 공통 "미팅 종류 선택" 페이지 제작

### DIFF
--- a/public/images/icons/arrow-black.svg
+++ b/public/images/icons/arrow-black.svg
@@ -1,0 +1,9 @@
+<svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<rect x="0.5" y="0.75" width="6" height="10.5" fill="url(#pattern0)"/>
+<defs>
+<pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2694_3539" transform="scale(0.25 0.142857)"/>
+</pattern>
+<image id="image0_2694_3539" width="4" height="7" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAHCAYAAAAvZezQAAAAAXNSR0IArs4c6QAAACZJREFUGFdjbOmZ9r+mJIuRAQrADGRBuAxMEC4AU4ldBYoZ6LYAADLjGq16wxUbAAAAAElFTkSuQmCC"/>
+</defs>
+</svg>

--- a/src/components/buttons/checkbox/Checkbox.style.ts
+++ b/src/components/buttons/checkbox/Checkbox.style.ts
@@ -2,12 +2,12 @@ import styled from '@emotion/styled';
 import { colors } from '~/styles/colors';
 import { CheckboxProps } from './Checkbox';
 
-type SWrapperProps = Pick<CheckboxProps, 'checked'>;
+type SWrapperProps = Omit<CheckboxProps, 'onClick'>;
 
 const S = {
   Wrapper: styled.div<SWrapperProps>`
-    height: 24px;
-    width: 24px;
+    height: ${({ height }) => `${height}px`};
+    width: ${({ width }) => `${width}px`};
     border-radius: 2px;
     border: 0.5px solid ${colors.Gray500};
     background: ${colors.White};

--- a/src/components/buttons/checkbox/Checkbox.tsx
+++ b/src/components/buttons/checkbox/Checkbox.tsx
@@ -2,7 +2,7 @@ import S from './Checkbox.style';
 
 export type CheckboxProps = {
   checked: boolean;
-  onClick: () => void;
+  onClick?: () => void;
   height?: number;
   width?: number;
 };

--- a/src/components/buttons/checkbox/Checkbox.tsx
+++ b/src/components/buttons/checkbox/Checkbox.tsx
@@ -3,11 +3,22 @@ import S from './Checkbox.style';
 export type CheckboxProps = {
   checked: boolean;
   onClick: () => void;
+  height?: number;
+  width?: number;
 };
 
-const Checkbox = ({ checked, onClick }: CheckboxProps) => {
+const Checkbox = ({
+  checked,
+  onClick,
+  height = 24,
+  width = 24,
+}: CheckboxProps) => {
   return (
-    <S.Wrapper checked={checked} onClick={onClick}>
+    <S.Wrapper
+      checked={checked}
+      onClick={onClick}
+      height={height}
+      width={width}>
       {/* TODO: img를 Icon 컴포넌트로 교체 */}
       {checked && <img src="/images/icons/checkbox-check.png" width={20} />}
     </S.Wrapper>

--- a/src/components/buttons/roundButton/RoundButton.tsx
+++ b/src/components/buttons/roundButton/RoundButton.tsx
@@ -25,7 +25,7 @@ const RoundButton = ({
   textColor,
   textTypography,
   width = 'full',
-  height = 40,
+  height = 56,
   onClick,
   hasBorder = false,
   borderType = 'primary',

--- a/src/components/layout/Col.tsx
+++ b/src/components/layout/Col.tsx
@@ -53,11 +53,5 @@ const Container = styled.div<ColProps>`
   align-items: ${({ align }) => align};
   gap: ${({ gap }) => gap}px;
   padding: ${({ padding }) => padding};
-  height: 100%;
   width: 100%;
-  ${fill =>
-    fill &&
-    css`
-      flex: 1;
-    `}
 `;

--- a/src/pages/common/branchGatewayStep/FirstPage.tsx
+++ b/src/pages/common/branchGatewayStep/FirstPage.tsx
@@ -1,47 +1,111 @@
 import Col from '~/components/layout/Col';
 import Text from '~/components/typography/Text';
 import { useAtom, useSetAtom } from 'jotai';
-import { univTypeAtom } from '~/store/meeting';
+import { meetingTypeAtom, meetingTypeCheckAtom } from '~/store/meeting';
 import { useEffect } from 'react';
 import { pageFinishAtom } from '~/store/funnel';
 import RoundButton from '~/components/buttons/roundButton/RoundButton';
+import Paddler from '~/components/layout/Pad';
+import { css } from '@emotion/react';
+import Row from '~/components/layout/Row';
+import Checkbox from '~/components/buttons/checkbox/Checkbox';
+import IconButton from '~/components/buttons/iconButton/IconButton';
+import { useImmerAtom } from 'jotai-immer';
+
+const MEETING_TYPE_BUTTONS = [
+  {
+    label: '1:1 미팅',
+    type: 'personal',
+  },
+  {
+    label: '3:3 미팅',
+    type: 'group',
+  },
+] as const;
 
 const FirstPage = () => {
-  const [univAtom, setUnivAtom] = useAtom(univTypeAtom);
+  const [meetingTypeValue, setMeetingTypeValue] = useAtom(meetingTypeAtom);
+  const [meetingTypeCheckValue, setMeetingTypeCheckValue] =
+    useImmerAtom(meetingTypeCheckAtom);
   const setIsPageFinished = useSetAtom(pageFinishAtom);
 
   useEffect(() => {
-    if (univAtom) {
-      setIsPageFinished(true);
-    }
-  }, [univAtom, setUnivAtom]);
+    if (meetingTypeCheckValue.every(value => value)) setIsPageFinished(true);
+    else setIsPageFinished(false);
+  }, [meetingTypeCheckValue, setMeetingTypeCheckValue]);
 
   return (
-    <Col align={'center'} gap={52}>
-      <Text
-        label={'참여하고자 하는 미팅 종류를 선택해주세요'}
-        color={'Gray500'}
-        typography={'NeoTitleM'}
-      />
-      <Text
-        label={
-          '서울시립대학교 구성원만 신청 가능하며\n' +
-          '3:3 미팅의 경우 함께 나갈 인원을 모아야 신청이 가능해요.'
-        }
-        color={'Gray400'}
-        typography={'GoThicBodyS'}
-      />
-      <Col>
-        <RoundButton
-          status={'inactive'}
-          label={'1:1 미팅'}
-          onClick={() => console.log('asd')}
+    <Col align={'center'} gap={20}>
+      <Col gap={12} align={'center'}>
+        <Text
+          label={'참여하고자 하는 미팅 종류를 선택해주세요'}
+          color={'Gray500'}
+          typography={'NeoTitleM'}
         />
-        <RoundButton
-          status={'inactive'}
-          label={'3:3 미팅'}
-          onClick={() => console.log('asd')}
+        <Text
+          label={
+            '서울시립대학교 구성원만 신청 가능하며\n' +
+            '3:3 미팅의 경우 함께 나갈 인원을 모아야 신청이 가능해요.'
+          }
+          color={'Gray400'}
+          typography={'GoThicBodyS'}
+          css={css`
+            text-align: center;
+          `}
         />
+      </Col>
+      <Paddler top={8}>
+        <Col gap={8}>
+          {MEETING_TYPE_BUTTONS.map((value, index) => (
+            <RoundButton
+              key={`${value.label} ${index}`}
+              status={meetingTypeValue === value.type ? 'active' : 'inactive'}
+              label={value.label}
+              textTypography={'NeoButtonL'}
+              textColor={'Primary500'}
+              onClick={() => setMeetingTypeValue(value.type)}
+            />
+          ))}
+        </Col>
+      </Paddler>
+      <Col gap={8}>
+        <Row align={'center'} justify={'space-between'}>
+          <Row gap={8}>
+            <Checkbox
+              checked={meetingTypeCheckValue[0]}
+              height={16}
+              width={16}
+              onClick={() =>
+                setMeetingTypeCheckValue(draft => {
+                  draft[0] = !draft[0];
+                })
+              }
+            />
+            <Text
+              label={'개인정보 활용 정보 제공에 동의합니다.'}
+              color={'Gray300'}
+              typography={'PretendardRegular'}
+            />
+          </Row>
+          <IconButton iconName={'arrow-black'} height={10} width={6} />
+        </Row>
+        <Row align={'center'} gap={8}>
+          <Checkbox
+            checked={meetingTypeCheckValue[1]}
+            height={16}
+            width={16}
+            onClick={() =>
+              setMeetingTypeCheckValue(draft => {
+                draft[1] = !draft[1];
+              })
+            }
+          />
+          <Text
+            label={'경희대, 외대, 시립대 재학생 인증을 완료하였습니다.'}
+            color={'Gray300'}
+            typography={'PretendardRegular'}
+          />
+        </Row>
       </Col>
     </Col>
   );

--- a/src/pages/common/branchGatewayStep/FirstPage.tsx
+++ b/src/pages/common/branchGatewayStep/FirstPage.tsx
@@ -1,5 +1,50 @@
+import Col from '~/components/layout/Col';
+import Text from '~/components/typography/Text';
+import { useAtom, useSetAtom } from 'jotai';
+import { univTypeAtom } from '~/store/meeting';
+import { useEffect } from 'react';
+import { pageFinishAtom } from '~/store/funnel';
+import RoundButton from '~/components/buttons/roundButton/RoundButton';
+
 const FirstPage = () => {
-  return <div>첫 번째 페이지</div>;
+  const [univAtom, setUnivAtom] = useAtom(univTypeAtom);
+  const setIsPageFinished = useSetAtom(pageFinishAtom);
+
+  useEffect(() => {
+    if (univAtom) {
+      setIsPageFinished(true);
+    }
+  }, [univAtom, setUnivAtom]);
+
+  return (
+    <Col align={'center'} gap={52}>
+      <Text
+        label={'참여하고자 하는 미팅 종류를 선택해주세요'}
+        color={'Gray500'}
+        typography={'NeoTitleM'}
+      />
+      <Text
+        label={
+          '서울시립대학교 구성원만 신청 가능하며\n' +
+          '3:3 미팅의 경우 함께 나갈 인원을 모아야 신청이 가능해요.'
+        }
+        color={'Gray400'}
+        typography={'GoThicBodyS'}
+      />
+      <Col>
+        <RoundButton
+          status={'inactive'}
+          label={'1:1 미팅'}
+          onClick={() => console.log('asd')}
+        />
+        <RoundButton
+          status={'inactive'}
+          label={'3:3 미팅'}
+          onClick={() => console.log('asd')}
+        />
+      </Col>
+    </Col>
+  );
 };
 
 export default FirstPage;

--- a/src/pages/common/branchGatewayStep/FirstPage.tsx
+++ b/src/pages/common/branchGatewayStep/FirstPage.tsx
@@ -31,6 +31,11 @@ const FirstPage = () => {
   const setIsPageFinished = useSetAtom(pageFinishAtom);
   const navigate = useNavigate();
 
+  const handleSetMeetingTypeCheckValue = (order: number) =>
+    setMeetingTypeCheckValue(draft => {
+      draft[order] = !draft[order];
+    });
+
   useEffect(() => {
     if (meetingTypeCheckValue.every(value => value)) setIsPageFinished(true);
     else setIsPageFinished(false);
@@ -72,16 +77,14 @@ const FirstPage = () => {
       </Paddler>
       <Col gap={8}>
         <Row align={'center'} justify={'space-between'}>
-          <Row gap={8}>
+          <Row
+            align={'center'}
+            gap={8}
+            onClick={() => handleSetMeetingTypeCheckValue(0)}>
             <Checkbox
               checked={meetingTypeCheckValue[0]}
               height={16}
               width={16}
-              onClick={() =>
-                setMeetingTypeCheckValue(draft => {
-                  draft[0] = !draft[0];
-                })
-              }
             />
             <Text
               label={'개인정보 활용 정보 제공에 동의합니다.'}
@@ -96,17 +99,11 @@ const FirstPage = () => {
             onClick={() => navigate('/common/privacyPolicyStep')}
           />
         </Row>
-        <Row align={'center'} gap={8}>
-          <Checkbox
-            checked={meetingTypeCheckValue[1]}
-            height={16}
-            width={16}
-            onClick={() =>
-              setMeetingTypeCheckValue(draft => {
-                draft[1] = !draft[1];
-              })
-            }
-          />
+        <Row
+          align={'center'}
+          gap={8}
+          onClick={() => handleSetMeetingTypeCheckValue(1)}>
+          <Checkbox checked={meetingTypeCheckValue[1]} height={16} width={16} />
           <Text
             label={'경희대, 외대, 시립대 재학생 인증을 완료하였습니다.'}
             color={'Gray300'}

--- a/src/pages/common/branchGatewayStep/FirstPage.tsx
+++ b/src/pages/common/branchGatewayStep/FirstPage.tsx
@@ -11,6 +11,7 @@ import Row from '~/components/layout/Row';
 import Checkbox from '~/components/buttons/checkbox/Checkbox';
 import IconButton from '~/components/buttons/iconButton/IconButton';
 import { useImmerAtom } from 'jotai-immer';
+import { useNavigate } from 'react-router-dom';
 
 const MEETING_TYPE_BUTTONS = [
   {
@@ -28,6 +29,7 @@ const FirstPage = () => {
   const [meetingTypeCheckValue, setMeetingTypeCheckValue] =
     useImmerAtom(meetingTypeCheckAtom);
   const setIsPageFinished = useSetAtom(pageFinishAtom);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (meetingTypeCheckValue.every(value => value)) setIsPageFinished(true);
@@ -87,7 +89,12 @@ const FirstPage = () => {
               typography={'PretendardRegular'}
             />
           </Row>
-          <IconButton iconName={'arrow-black'} height={10} width={6} />
+          <IconButton
+            iconName={'arrow-black'}
+            height={10}
+            width={6}
+            onClick={() => navigate('/common/privacyPolicyStep')}
+          />
         </Row>
         <Row align={'center'} gap={8}>
           <Checkbox

--- a/src/pages/common/branchGatewayStep/Step.tsx
+++ b/src/pages/common/branchGatewayStep/Step.tsx
@@ -1,12 +1,18 @@
 import PageLayout from '~/components/layout/page/PageLayout';
 import { useFunnel } from '~/hooks/useFunnel';
 import FirstPage from './FirstPage';
+import { meetingTypeAtom } from '~/store/meeting';
+import { useAtomValue } from 'jotai';
 
 const BranchGatewayStep = () => {
+  const meetingTypeValue = useAtomValue(meetingTypeAtom);
   const { Funnel, currentPage, PageHandler } = useFunnel({
     pageNumberList: [1],
     nextStep: {
-      path: '/group/myInformationStep',
+      path:
+        meetingTypeValue === 'group'
+          ? '/group/myInformationStep'
+          : '/personal/myInformationStep',
     },
     prevStep: {
       path: '/common/univVerificationStep',

--- a/src/pages/common/branchGatewayStep/Step.tsx
+++ b/src/pages/common/branchGatewayStep/Step.tsx
@@ -16,11 +16,13 @@ const BranchGatewayStep = () => {
   return (
     <PageLayout>
       <PageLayout.Header title={'시대팅 종류 선택'} isProgress={false} />
-      <Funnel>
-        <Funnel.Page pageNumber={1}>
-          <FirstPage />
-        </Funnel.Page>
-      </Funnel>
+      <PageLayout.SingleCardBody>
+        <Funnel>
+          <Funnel.Page pageNumber={1}>
+            <FirstPage />
+          </Funnel.Page>
+        </Funnel>
+      </PageLayout.SingleCardBody>
       <PageLayout.Footer
         currentPage={currentPage}
         totalPage={1}

--- a/src/pages/group/myInfomationStep/Step.tsx
+++ b/src/pages/group/myInfomationStep/Step.tsx
@@ -9,7 +9,7 @@ const MyInformationStep = () => {
   const { Funnel, currentPage, PageHandler } = useFunnel({
     pageNumberList: PAGE_NUMBER,
     nextStep: { path: '/common/privacyPolicy' },
-    prevStep: { path: '/group/groupRoleSelectStep' },
+    prevStep: { path: '/common/branchGateWayStep' },
   });
 
   return (

--- a/src/routes/groupRoutes.tsx
+++ b/src/routes/groupRoutes.tsx
@@ -1,4 +1,4 @@
-import MyInformationStep from '~/pages/personal/myInformationStep/Step';
+import MyInformationStep from '~/pages/group/myInfomationStep/Step';
 import MyRomanceStep from '~/pages/personal/myRomanceStep/Step';
 import MyPreferTypeStep from '~/pages/personal/myPreferTypeStep/Step';
 import GroupRoleSelectStep from '~/pages/group/groupRoleSelectStep/Step';

--- a/src/store/meeting/common.ts
+++ b/src/store/meeting/common.ts
@@ -6,6 +6,9 @@ meetingTypeAtom.debugLabel = 'meetingTypeAtom';
 export const univTypeAtom = atom<'HUFS' | 'KHU' | 'UOS' | null>(null);
 univTypeAtom.debugLabel = 'univTypeAtom';
 
+export const meetingTypeCheckAtom = atom([false, false]);
+meetingTypeCheckAtom.debugLabel = 'meetingTypeCheckAtom';
+
 export type CommonApplyInfo = {
   info_nickname: string;
   info_gender: string;

--- a/src/types/icon.type.ts
+++ b/src/types/icon.type.ts
@@ -7,8 +7,9 @@ export type normalType =
   | 'check'
   | 'headerButton-home'
   | 'headerButton-backArrow'
-  | 'participationModal-human';
-  | 'dropdown';
+  | 'participationModal-human'
+  | 'dropdown'
+  | 'arrow-black';
 
 // 동물상
 export type animalKeyType =


### PR DESCRIPTION
# 공통 "미팅 종류 선택" 페이지 제작

## 개요 
- 검정색 화살표 아이콘을 추가했습니다.
- CheckButton 컴포넌트의 크기를 props로 받도록 했습니다.
- RoundButton 컴포넌트의 height prop 기본값을 변경했습니다.
- 미팅 종류 선택 페이지의 체크 버튼 값을 관리할 전역 변수를 만들었습니다.
- 미팅 종류 선택 페이지 제작했습니다.
- 개인정보 처리방침 페이지로 navigate 기능을 추가했습니다.
- 미팅 종류 선택에 다른 1:1 / 3:3 라우트 분기 처리를 미팅 종류 전역 변수에 따라 진행했습니다. 

## 상세설명 

**공통 "미팅 종류 선택" 페이지를 보자면...** 
<img width="332" alt="image" src="https://github.com/uoslife/client-meeting-season4/assets/89263598/204f03ce-6b63-4763-9e19-a63cfddc32f6">

p.s. @limeojin363 CheckButton의 크기가 가변적이여서 width와 heigth를 props으로 받을 수 있게 추가했습니다. 또한 CheckButton의 onClick prop을 옵셔널로 처리해서, 체크버튼 옆 글자를 클릭해도 선택될 수 있게  ux 향상을 이유로 수정했습니다.

## 필요작업
**RoundButton 컴포넌트의 Text 컴포넌트 color 및 typhograph props 값은 RoundButton 컴포넌트의 status props에 따라 지정되도록 할 필요가 있어 보입니다.**
담당자 : @soeun2537 
1. RoundButton 컴포넌트 내부는 Text 컴포넌트가 있으며, 사용되는 Text 컴포넌트의 props은 RoundButton 컴포넌트를 사용하는 부모 컴포넌트에서 부여합니다.
<img width="582" alt="image" src="https://github.com/uoslife/client-meeting-season4/assets/89263598/a3e992e3-8187-4fd4-b414-733d4e532f07">

3. RoundButton 컴포넌트는 각 Status에 따라 각기 다른 색상의 글자색을 사용합니다. 그렇기에 RoundButton 컴포넌트에서 사용되는 Text 컴포넌트의 color props은 가변적으로 받아야만 합니다.
4. 하지만 현재 RoundButton 컴포넌트는 부모에서 사용할 때 color prop을 하나밖에 못 주며, 가변적으로 주려면 부모 컴포넌트에서 switch 문처럼 따로 분기 처리를 해줘야 합니다.
5. 이러한 방식은 부모 컴포넌트에게 너무나 많은 역할을 부여합니다. 
6. 현재 RoundButton 컴포넌트는 status에 따라 버튼 색상이 바뀝니다. 그렇기에 RoundButton 컴포넌트 내부는 Text 컴포넌트 역시 status 값에 따라 color 값이 바뀌도록 RoundButton 컴포넌트 내부적으로 처리할 필요가 있어 보입니다.
7. 글꼴 역시 NeoButton L가 일관되게 사용되기 때문에 굳이 prop으로 받을 이유가 없어 보입니다.
