### PR TITLE
feat[WEB-38]: 전역값 localStorage 적용

### DIFF
--- a/src/pages/common/univVerificationStep/FirstPage.tsx
+++ b/src/pages/common/univVerificationStep/FirstPage.tsx
@@ -3,25 +3,28 @@ import Text from '~/components/typography/Text';
 import Row from '~/components/layout/Row';
 import IconButton from '~/components/buttons/iconButton/IconButton';
 import { useAtom, useSetAtom } from 'jotai';
-import { groupApplyAtom, univTypeAtom } from '~/store/meeting';
+import {
+  commonApplyAtoms,
+  groupApplyAtom,
+  univTypeAtom,
+} from '~/store/meeting';
 import { useEffect } from 'react';
 import { pageFinishAtom } from '~/store/funnel';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { colors } from '~/styles/colors';
-import { useImmerAtom } from 'jotai-immer';
 
 const UNIV_SELECTION_LIST = ['KHU', 'HUFS'] as const;
 
 const FirstPage = () => {
-  const [univAtom, setUnivAtom] = useAtom(univTypeAtom);
+  const [univValue, setUnivValue] = useAtom(univTypeAtom);
   const setIsPageFinished = useSetAtom(pageFinishAtom);
 
   useEffect(() => {
-    if (univAtom) {
+    if (univValue) {
       setIsPageFinished(true);
     }
-  }, [univAtom, setUnivAtom]);
+  }, [univValue, setUnivValue]);
 
   // jotai 전역 변수가 groupApplyAtom처럼 객체라면 아래 코드처럼 useImmerAtom을 사용해보세요!
   // const [nickname, setNickname] = useImmerAtom(groupApplyAtom);
@@ -45,8 +48,8 @@ const FirstPage = () => {
           return (
             <UnivSelectContainer
               key={`${univ} - ${index}`}
-              isClicked={univAtom === univ}
-              onClick={() => setUnivAtom(univ)}>
+              isClicked={univValue === univ}
+              onClick={() => setUnivValue(univ)}>
               <IconButton
                 iconName={`univSelection/${univ}`}
                 format={'png'}

--- a/src/store/meeting/common.ts
+++ b/src/store/meeting/common.ts
@@ -1,19 +1,25 @@
-import { atom } from 'jotai';
 import { PrimitiveAtom } from 'jotai/vanilla';
+import { atomWithStorage } from 'jotai/utils';
 
-export const meetingTypeAtom = atom<'group' | 'personal' | null>(null);
+export const meetingTypeAtom = atomWithStorage<'group' | 'personal' | null>(
+  'meeting_type',
+  null,
+);
 meetingTypeAtom.debugLabel = 'meetingTypeAtom';
-export const univTypeAtom = atom<'HUFS' | 'KHU' | 'UOS' | null>(null);
+export const univTypeAtom = atomWithStorage<'HUFS' | 'KHU' | 'UOS' | null>(
+  'univ_type',
+  null,
+);
 univTypeAtom.debugLabel = 'univTypeAtom';
 
 export type CommonApplyInfo = {
-  info_nickname: string;
-  info_gender: string;
-  info_age: number;
-  info_height: number;
-  info_kakaoId: string;
-  info_major: string;
-  info_studentType: string;
+  myInfo_nickname: string;
+  myInfo_gender: string;
+  myInfo_age: number;
+  myInfo_height: number;
+  myInfo_kakaoId: string;
+  myInfo_major: string;
+  myInfo_studentType: string;
 };
 
 export type CommonApplyAtoms = {
@@ -21,11 +27,11 @@ export type CommonApplyAtoms = {
 };
 
 export const commonApplyAtoms: CommonApplyAtoms = {
-  info_nickname: atom(''),
-  info_gender: atom(''),
-  info_age: atom(0),
-  info_height: atom(0),
-  info_kakaoId: atom(''),
-  info_major: atom(''),
-  info_studentType: atom(''),
+  myInfo_nickname: atomWithStorage('myInfo_nickname', ''),
+  myInfo_gender: atomWithStorage('myInfo_gender', ''),
+  myInfo_age: atomWithStorage('myInfo_age', 0),
+  myInfo_height: atomWithStorage('myInfo_height', 0),
+  myInfo_kakaoId: atomWithStorage('myInfo_kakaoId', ''),
+  myInfo_major: atomWithStorage('myInfo_major', ''),
+  myInfo_studentType: atomWithStorage('myInfo_studentType', ''),
 };

--- a/src/store/meeting/group.ts
+++ b/src/store/meeting/group.ts
@@ -1,35 +1,37 @@
 import { ApplyQuestionArrType } from '~/types/apply.type';
-import { atom } from 'jotai';
 import { CommonApplyAtoms, commonApplyAtoms } from '.';
+import { atomWithStorage } from 'jotai/utils';
 
 export type GroupApplyInfo = {
-  code: string;
-  info_name: string;
-  info_preferDay: string[];
-  info_question: ApplyQuestionArrType;
-  prefer_age: string[];
-  prefer_major: string[];
-  prefer_atmosphere: string;
+  groupJoin_code: string;
+  groupInfo_name: string;
+  groupInfo_preferDay: string[];
+  groupInfo_question: ApplyQuestionArrType;
+  groupPrefer_age: string[];
+  groupPrefer_univ: string[];
+  groupPrefer_atmosphere: string;
 };
 
 export type GroupApplyAtoms = {
-  [key in keyof GroupApplyInfo]: ReturnType<typeof atom<GroupApplyInfo[key]>>;
+  [key in keyof GroupApplyInfo]: ReturnType<
+    typeof atomWithStorage<GroupApplyInfo[key]>
+  >;
 } & CommonApplyAtoms;
 
-export const groupApplyAtoms = {
+export const groupApplyAtoms: GroupApplyAtoms = {
   ...commonApplyAtoms,
-  code: atom(''),
-  info_name: atom(''),
-  info_preferDay: atom(['']),
-  info_question: atom([
+  groupJoin_code: atomWithStorage('groupJoin_code', ''),
+  groupInfo_name: atomWithStorage('groupInfo_name', ''),
+  groupInfo_preferDay: atomWithStorage('groupInfo_preferDay', ['']),
+  groupInfo_question: atomWithStorage('groupInfo_question', [
     { label: '', order: 0 },
     { label: '', order: 1 },
     { label: '', order: 2 },
     { label: '', order: 3 },
   ]),
-  prefer_age: atom(['']),
-  prefer_major: atom(['']),
-  prefer_atmosphere: atom(''),
+  groupPrefer_age: atomWithStorage('groupPrefer_age', ['']),
+  groupPrefer_univ: atomWithStorage('groupPrefer_univ', ['']),
+  groupPrefer_atmosphere: atomWithStorage('groupPrefer_atmosphere', ''),
 };
 
 for (const key in groupApplyAtoms) {

--- a/src/store/meeting/personal.ts
+++ b/src/store/meeting/personal.ts
@@ -1,56 +1,58 @@
 import { ApplyQuestionArrType } from '~/types/apply.type';
-import { atom } from 'jotai';
 import { CommonApplyAtoms, commonApplyAtoms } from '.';
+import { atomWithStorage } from 'jotai/utils';
 
 export type PersonalApplyInfo = {
-  info_drink: string[];
-  info_religion: string;
-  info_smoking: string;
-  info_animal: string[];
-  info_mbti: string[];
-  info_interests: string[];
-  info_question: ApplyQuestionArrType;
-  prefer_age: string[];
-  prefer_height: string[];
-  prefer_studentType: string[];
-  prefer_univ: string[];
-  prefer_drink: string[];
-  prefer_religion: string;
-  prefer_smoking: string;
-  prefer_animal: string[];
-  prefer_mbti: string[];
+  personalInfo_drink: string[];
+  personalInfo_religion: string;
+  personalInfo_smoking: string;
+  personalInfo_animal: string[];
+  personalInfo_mbti: string[];
+  personalInfo_interests: string[];
+  personalInfo_question: ApplyQuestionArrType;
+  personalPrefer_age: string[];
+  personalPrefer_height: string[];
+  personalPrefer_studentType: string[];
+  personalPrefer_univ: string[];
+  personalPrefer_drink: string[];
+  personalPrefer_religion: string;
+  personalPrefer_smoking: string;
+  personalPrefer_animal: string[];
+  personalPrefer_mbti: string[];
 };
 
 export type PesronalApplyAtoms = {
   [key in keyof PersonalApplyInfo]: ReturnType<
-    typeof atom<PersonalApplyInfo[key]>
+    typeof atomWithStorage<PersonalApplyInfo[key]>
   >;
 } & CommonApplyAtoms;
 
 export const personalApplyAtoms: PesronalApplyAtoms = {
   ...commonApplyAtoms,
-  info_religion: atom(''),
-  info_smoking: atom(''),
-  info_drink: atom(['']),
-  info_animal: atom(['']),
-  info_mbti: atom(['', '', '', '']),
-  info_interests: atom(['']),
-  info_question: atom([
+  personalInfo_drink: atomWithStorage('personalInfo_drink', ['']),
+  personalInfo_smoking: atomWithStorage('personalInfo_smoking', ''),
+  personalInfo_religion: atomWithStorage('personalInfo_religion', ''),
+  personalInfo_animal: atomWithStorage('personalInfo_animal', ['']),
+  personalInfo_mbti: atomWithStorage('personalInfo_mbti', ['', '', '', '']),
+  personalInfo_interests: atomWithStorage('personalInfo_interests', ['']),
+  personalInfo_question: atomWithStorage('personalInfo_question', [
     { label: '', order: 0 },
     { label: '', order: 1 },
     { label: '', order: 2 },
     { label: '', order: 3 },
     { label: '', order: 4 },
   ]),
-  prefer_age: atom(['']),
-  prefer_height: atom(['']),
-  prefer_studentType: atom(['']),
-  prefer_univ: atom(['']),
-  prefer_smoking: atom(''),
-  prefer_religion: atom(''),
-  prefer_drink: atom(['']),
-  prefer_animal: atom(['']),
-  prefer_mbti: atom(['']),
+  personalPrefer_age: atomWithStorage('personalPrefer_age', ['']),
+  personalPrefer_height: atomWithStorage('personalPrefer_height', ['']),
+  personalPrefer_studentType: atomWithStorage('personalPrefer_studentType', [
+    '',
+  ]),
+  personalPrefer_univ: atomWithStorage('personalPrefer_univ', ['']),
+  personalPrefer_smoking: atomWithStorage('personalPrefer_smoking', ''),
+  personalPrefer_religion: atomWithStorage('personalPrefer_religion', ''),
+  personalPrefer_drink: atomWithStorage('personalPrefer_drink', ['']),
+  personalPrefer_animal: atomWithStorage('personalPrefer_animal', ['']),
+  personalPrefer_mbti: atomWithStorage('personalPrefer_mbti', ['']),
 };
 
 for (const key in personalApplyAtoms) {

--- a/src/types/apply.type.ts
+++ b/src/types/apply.type.ts
@@ -1,4 +1,4 @@
 export type ApplyQuestionArrType = Array<{
-  selectedAnswerOption: string;
+  label: string;
   order: number;
 }>;


### PR DESCRIPTION
# 전역값 localStorage 적용

## 개요 
- atom으로 되어 있는 전역 변수를 atomWithStorage로 적용하여, 전역값이 localStorage로 관리될 수 있게 했습니다.
- common,personal,group에 맞춰 헷갈릴 가능성이 높은 변수들의 이름을 수정했습니다

## 상세설명 
**atomWithStorage에 대해 보자면...** 
atomWithStorage의 이용법은 기존 atom과 동일합니다.
<img width="640" alt="image" src="https://github.com/uoslife/client-meeting-season4/assets/89263598/1c012095-b2f7-402f-8e95-dd102f25ebce">
예를 들어, univTypeAtom은 atomWithStorage로 적용된 전역 값입니다. 그렇기에 해당 값은 새로고침을 해도 초기 값으로 돌아가지 않습니다.
해당 값은 jotai devtool에서 확인 가능하며, localStorage에서도 확인 가능합니다.
<img width="1476" alt="image" src="https://github.com/uoslife/client-meeting-season4/assets/89263598/20f8fd15-6d88-46a4-8c4e-acd71c012fbc">
<참고자료>
https://jotai.org/docs/utilities/storage
https://velog.io/@heeppyea/atomWithStorage

### 현재 변수명이 바뀌어 있는 상태입니다. 그렇기에, 전역 값을 이용하시는 개발자분께서는 변경된 전역 변수명에 맞추어서 자신이 만든 페이지의 전역 변수명도 바꾸어주시길 바랍니다.