### PR TITLE
feat[WEB-43]: 3:3 "미팅 참여 역할 선택" 페이지 제작

### DIFF
--- a/src/pages/common/branchGatewayStep/FirstPage.tsx
+++ b/src/pages/common/branchGatewayStep/FirstPage.tsx
@@ -2,7 +2,7 @@ import Col from '~/components/layout/Col';
 import Text from '~/components/typography/Text';
 import { useAtom, useSetAtom } from 'jotai';
 import { meetingTypeAtom, meetingTypeCheckAtom } from '~/store/meeting';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { pageFinishAtom } from '~/store/funnel';
 import RoundButton from '~/components/buttons/roundButton/RoundButton';
 import Paddler from '~/components/layout/Pad';
@@ -37,12 +37,18 @@ const FirstPage = () => {
     });
 
   useEffect(() => {
-    if (meetingTypeCheckValue.every(value => value)) setIsPageFinished(true);
+    if (meetingTypeCheckValue.every(value => value) && meetingTypeValue)
+      setIsPageFinished(true);
     else setIsPageFinished(false);
-  }, [meetingTypeCheckValue, setMeetingTypeCheckValue]);
+  }, [
+    meetingTypeCheckValue,
+    setMeetingTypeCheckValue,
+    meetingTypeValue,
+    setMeetingTypeValue,
+  ]);
 
   return (
-    <Col align={'center'} gap={20}>
+    <Col align={'center'} gap={20} padding={'36px 20px'}>
       <Col gap={12} align={'center'}>
         <Text
           label={'참여하고자 하는 미팅 종류를 선택해주세요'}
@@ -68,8 +74,6 @@ const FirstPage = () => {
               key={`${value.label} ${index}`}
               status={meetingTypeValue === value.type ? 'active' : 'inactive'}
               label={value.label}
-              textTypography={'NeoButtonL'}
-              textColor={'Primary500'}
               onClick={() => setMeetingTypeValue(value.type)}
             />
           ))}

--- a/src/pages/common/branchGatewayStep/Step.tsx
+++ b/src/pages/common/branchGatewayStep/Step.tsx
@@ -11,7 +11,7 @@ const BranchGatewayStep = () => {
     nextStep: {
       path:
         meetingTypeValue === 'group'
-          ? '/group/myInformationStep'
+          ? '/group/groupRoleSelectStep'
           : '/personal/myInformationStep',
     },
     prevStep: {

--- a/src/pages/common/univVerificationStep/FirstPage.tsx
+++ b/src/pages/common/univVerificationStep/FirstPage.tsx
@@ -3,11 +3,7 @@ import Text from '~/components/typography/Text';
 import Row from '~/components/layout/Row';
 import IconButton from '~/components/buttons/iconButton/IconButton';
 import { useAtom, useSetAtom } from 'jotai';
-import {
-  commonApplyAtoms,
-  groupApplyAtom,
-  univTypeAtom,
-} from '~/store/meeting';
+import { univTypeAtom } from '~/store/meeting';
 import { useEffect } from 'react';
 import { pageFinishAtom } from '~/store/funnel';
 import styled from '@emotion/styled';

--- a/src/pages/group/groupRoleSelectStep/FirstPage.tsx
+++ b/src/pages/group/groupRoleSelectStep/FirstPage.tsx
@@ -1,5 +1,80 @@
+import Col from '~/components/layout/Col';
+import Text from '~/components/typography/Text';
+import { useAtom, useSetAtom } from 'jotai';
+import { groupApplyAtoms } from '~/store/meeting';
+import { useEffect } from 'react';
+import { pageFinishAtom } from '~/store/funnel';
+import RoundButton from '~/components/buttons/roundButton/RoundButton';
+import Paddler from '~/components/layout/Pad';
+import { css } from '@emotion/react';
+
+const GROUP_ROLE_BUTTONS = [
+  {
+    label: '팅 만들기',
+    isLeader: true,
+  },
+  {
+    label: '팅 참여하기',
+    isLeader: false,
+  },
+] as const;
+
 const FirstPage = () => {
-  return <div>첫 번째 페이지</div>;
+  const [isLeaderValue, setIsLeaderValue] = useAtom(
+    groupApplyAtoms.groupRole_isLeader,
+  );
+  const setIsPageFinished = useSetAtom(pageFinishAtom);
+
+  useEffect(() => {
+    if (isLeaderValue != null) setIsPageFinished(true);
+    else setIsPageFinished(false);
+  }, [isLeaderValue, setIsLeaderValue]);
+
+  return (
+    <Col align={'center'} gap={20} padding={'36px 20px'}>
+      <Col gap={12} align={'center'}>
+        <Text
+          label={'모임을 만드시나요? 참여하시나요?'}
+          color={'Gray500'}
+          typography={'NeoTitleM'}
+        />
+        <Text
+          label={
+            '팅을 만드는 팅장은 발급 받은 팅 코드를\n' +
+            '팅원들에게 알려주고 팅에 대한 정보를 입력하게 돼요.'
+          }
+          color={'Gray400'}
+          typography={'GoThicBodyS'}
+          css={css`
+            text-align: center;
+          `}
+        />
+        <Text
+          label={
+            '그 외 이미 만들어진 팅에 참여하시는 경우,\n' +
+            '팅장에게 전달 받은 팅 코드를 입력하면 참여 가능해요.'
+          }
+          color={'Gray400'}
+          typography={'GoThicBodyS'}
+          css={css`
+            text-align: center;
+          `}
+        />
+      </Col>
+      <Paddler top={8}>
+        <Col gap={8}>
+          {GROUP_ROLE_BUTTONS.map((value, index) => (
+            <RoundButton
+              key={`${value.label} ${index}`}
+              status={isLeaderValue === value.isLeader ? 'active' : 'inactive'}
+              label={value.label}
+              onClick={() => setIsLeaderValue(value.isLeader)}
+            />
+          ))}
+        </Col>
+      </Paddler>
+    </Col>
+  );
 };
 
 export default FirstPage;

--- a/src/pages/group/groupRoleSelectStep/Step.tsx
+++ b/src/pages/group/groupRoleSelectStep/Step.tsx
@@ -1,26 +1,26 @@
 import PageLayout from '~/components/layout/page/PageLayout';
-import FirstPage from '~/pages/common/applyPledgeStep/FirstPage';
+import FirstPage from './FirstPage';
 import { useFunnel } from '~/hooks/useFunnel';
 
 const GroupRoleSelectStep = () => {
   const { Funnel, currentPage, PageHandler } = useFunnel({
     pageNumberList: [1],
-    nextStep: { path: '/group/groupInformationStep' },
+    nextStep: { path: '/group/myInformationStep' },
     prevStep: { path: '/common/branchGateWayStep' },
   });
-
-  // 그룹을 만들지, 참여할지에 따른 navigate 분기 처리 필요.
 
   return (
     <PageLayout>
       <PageLayout.Header title={'3:3 미팅'} isProgress={false} />
-      <Funnel>
-        <Funnel.Page pageNumber={1}>
-          <FirstPage />
-        </Funnel.Page>
-      </Funnel>
+      <PageLayout.SingleCardBody>
+        <Funnel>
+          <Funnel.Page pageNumber={1}>
+            <FirstPage />
+          </Funnel.Page>
+        </Funnel>
+      </PageLayout.SingleCardBody>
       <PageLayout.Footer
-        currentPage={1}
+        currentPage={currentPage}
         totalPage={1}
         onNext={PageHandler.onNext}
         onPrev={PageHandler.onPrev}

--- a/src/store/meeting/group.ts
+++ b/src/store/meeting/group.ts
@@ -3,6 +3,7 @@ import { CommonApplyAtoms, commonApplyAtoms } from '.';
 import { atomWithStorage } from 'jotai/utils';
 
 export type GroupApplyInfo = {
+  groupRole_isLeader: boolean | null;
   groupJoin_code: string;
   groupInfo_name: string;
   groupInfo_preferDay: string[];
@@ -20,6 +21,10 @@ export type GroupApplyAtoms = {
 
 export const groupApplyAtoms: GroupApplyAtoms = {
   ...commonApplyAtoms,
+  groupRole_isLeader: atomWithStorage<boolean | null>(
+    'groupRole_isLeader',
+    null,
+  ),
   groupJoin_code: atomWithStorage('groupJoin_code', ''),
   groupInfo_name: atomWithStorage('groupInfo_name', ''),
   groupInfo_preferDay: atomWithStorage('groupInfo_preferDay', ['']),


### PR DESCRIPTION
# 3:3 "미팅 참여 역할 선택" 페이지 제작

## 개요
- 3:3 미팅에서 참여자인지 생성자인지 역할을 선택하는 페이지를 제작했습니다.
- 참여자인지 생성자인지를 구분짓기 위해 groupApplyAtom에 isLeader라는 전역 값을 추가했습니다.

## 상세설명
**공통 "대학 이메일 인증" 페이지를 보자면...**
<img width="219" alt="image" src="https://github.com/uoslife/client-meeting-season4/assets/89263598/340bb45c-33b8-4b54-8459-273ea89639ae">


## 이슈
- RoundButton의 transition이 동작하지 않는 경우가 있습니다.
<img width="663" alt="image" src="https://github.com/uoslife/client-meeting-season4/assets/89263598/ac98f72e-cbf4-44ac-875e-7f3f2a643a1a">

해당 값처럼 status에 따라 버튼의 색상이 변합니다. string 값끼리 서로 같은지 틀린지 판별하는 식에서는 transition이 동작하지 않습니다.
<img width="597" alt="image" src="https://github.com/uoslife/client-meeting-season4/assets/89263598/233a1083-8ab1-43dd-ba2d-89c51be3dba2">
하지만 boolean 값끼리 서로 같은지 틀린지 판별하는 식에서는 transition이 동작합니다.

해당 이슈는 깃허브 이슈 카테고리에 등록해놨습니다.