### PR TITLE
fix[WEB-51]: RangeSlider 스타일 조정

### DIFF
--- a/src/components/rangeSlider/RangeSlider.style.ts
+++ b/src/components/rangeSlider/RangeSlider.style.ts
@@ -5,29 +5,31 @@ const S = {
   EntireContainer: styled.div`
     position: relative;
     width: 100%;
-    height: 15px;
-    margin-top: 100px;
+    height: 36px;
+  `,
+  BackgroundContainer: styled.div`
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 8px;
+  `,
+  SliderContainer: styled.div`
+    position: absolute;
+    top: 0;
+    width: 100%;
 
     /* Origin: "node_modules\rc-slider\assets\index.css") */
     .rc-slider {
       position: relative;
       width: 100%;
       height: 100%;
-      padding: 5px 0;
-      border-radius: 6px;
+      height: 8px;
       touch-action: none;
       display: flex;
       align-items: center;
     }
     .rc-slider * {
       box-sizing: border-box;
-    }
-    .rc-slider-rail {
-      position: absolute;
-      width: 100%;
-      height: 4px;
-      background-color: transparent;
-      border-radius: 6px;
     }
     .rc-slider-track,
     .rc-slider-tracks {
@@ -65,25 +67,11 @@ const S = {
       cursor: pointer;
     }
   `,
-  BackgroundContainer: styled.div`
-    position: absolute;
-    top: 50%;
-    transform: translate(0, -50%);
-    width: 100%;
-    height: 100%;
-  `,
-  SliderContainer: styled.div`
-    position: absolute;
-    top: 50%;
-    transform: translate(0, -50%);
-    width: 100%;
-    height: 100%;
-  `,
   CustomHandleContainer: styled.div`
     height: 150%;
   `,
   MarkTextContainer: styled.div`
-    padding-top: 20px;
+    padding-top: 12px;
   `,
 };
 

--- a/src/components/rangeSlider/RangeSliderBackground.tsx
+++ b/src/components/rangeSlider/RangeSliderBackground.tsx
@@ -37,9 +37,9 @@ const getRowsInfo = () => {
   for (let i = 3; i < 6; i++) ret[i].backgroundColorName = 'Gray200';
   for (let i = 6; i < 8; i++) ret[i].backgroundColorName = 'Gray300';
 
-  ret[0].widthSubtrahend = ret[rowCount - 1 - 0].widthSubtrahend = 2.5;
-  ret[1].widthSubtrahend = ret[rowCount - 1 - 1].widthSubtrahend = 1.5;
-  ret[2].widthSubtrahend = ret[rowCount - 1 - 2].widthSubtrahend = 0.5;
+  ret[0].widthSubtrahend = ret[rowCount - 1 - 0].widthSubtrahend = 1.5;
+  ret[1].widthSubtrahend = ret[rowCount - 1 - 1].widthSubtrahend = 0.9;
+  ret[2].widthSubtrahend = ret[rowCount - 1 - 2].widthSubtrahend = 0.3;
   ret[3].widthSubtrahend = ret[rowCount - 1 - 3].widthSubtrahend = 0;
 
   return ret;


### PR DESCRIPTION
# Summary

- 불필요한 margin-top을 없애고, 슬라이더 영역의 height를 줄였습니다.
- height에 절댓값을 지정해 주었습니다. 이제 하단의 mark와 아래에 있는 다른 컴포넌트들이 겹치지 않습니다.