### PR TITLE
feat[WEB-50]: 1:1 "선호하는 상대 정보 입력하기" 페이지 제작

### DIFF
--- a/src/components/buttons/mbtiButton/MbtiButton.style.tsx
+++ b/src/components/buttons/mbtiButton/MbtiButton.style.tsx
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+import { colors } from '~/styles/colors';
+import { MbtiButtonProps } from './MbtiButton';
+
+type StyledProps = Pick<MbtiButtonProps, 'width' | 'height' | 'status'>;
+
+export const Button = styled.button<StyledProps>`
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 10px 10px;
+  border: 1px solid ${colors.Primary500};
+  border-radius: 10px;
+  width: ${({ width }) => (width === 'full' ? '100%' : `${width}px`)};
+  height: ${({ height }) => `${height}px`};
+  background-color: ${({ status }) =>
+    status === 'active' ? colors.Primary500 : colors.White};
+  transition: 0.5s;
+`;

--- a/src/components/buttons/mbtiButton/MbtiButton.tsx
+++ b/src/components/buttons/mbtiButton/MbtiButton.tsx
@@ -1,0 +1,49 @@
+import * as S from './MbtiButton.style';
+import Text from '~/components/typography/Text';
+
+export type MbtiButtonProps = {
+  status: 'active' | 'inactive';
+  alphabet: string;
+  label: string;
+  width?: number | 'full';
+  height?: number;
+  onClick: () => void;
+  children?: React.ReactNode;
+};
+
+const MbtiButton = ({
+  status,
+  alphabet,
+  label,
+  width = 'full',
+  height = 56,
+  onClick,
+  children,
+  ...props
+}: MbtiButtonProps) => {
+  return (
+    <S.Button
+      type={'button'}
+      status={status}
+      width={width}
+      height={height}
+      onClick={onClick}
+      {...props}>
+      <Text
+        label={alphabet}
+        color={status === 'active' ? 'White' : 'Primary500'}
+        typography={'NeoButtonL'}
+        size={36}
+      />
+      <Text
+        label={label}
+        color={status === 'active' ? 'White' : 'Primary500'}
+        typography={'NeoButtonL'}
+        size={16}
+      />
+      {children}
+    </S.Button>
+  );
+};
+
+export default MbtiButton;

--- a/src/hooks/useToggleSelect.tsx
+++ b/src/hooks/useToggleSelect.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
-export function useToggleSelect<T>(maxSelection?: number) {
-  const [selectedValues, setSelectedValues] = useState<T[]>([]);
+export function useToggleSelect<T>(maxSelection?: number, selectedArray?: T[]) {
+  const [selectedValues, setSelectedValues] = useState<T[]>(
+    selectedArray === undefined ? [] : selectedArray,
+  );
 
   const select = (value: T) => () => {
     if (selectedValues.includes(value)) {

--- a/src/pages/personal/myPreferTypeStep/FirstPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/FirstPage.tsx
@@ -1,5 +1,186 @@
+import PageLayout from '~/components/layout/page/PageLayout';
+import Paddler from '~/components/layout/Pad';
+import Col from '~/components/layout/Col';
+import Row from '~/components/layout/Row';
+import Text from '~/components/typography/Text';
+import RoundButton from '~/components/buttons/roundButton/RoundButton';
+import RangeSlider from '~/components/rangeSlider/RangeSlider';
+import useRangeState from '~/hooks/useRangeState';
+import { useEffect } from 'react';
+import { useAtom, useSetAtom } from 'jotai';
+import { personalApplyAtoms } from '~/store/meeting';
+import { pageFinishAtom } from '~/store/funnel';
+import { useToggleSelect } from '~/hooks/useToggleSelect';
+
 const FirstPage = () => {
-  return <div>첫 번째 페이지</div>;
+  const storedAge = localStorage.getItem('personalPrefer_age');
+  const parsedAge = storedAge === null ? [24, 27] : JSON.parse(storedAge);
+  const { rangeHandler: ageHandler, rangeValue: age } =
+    useRangeState(parsedAge);
+  const [, setAge] = useAtom(personalApplyAtoms.personalPrefer_age);
+
+  const storedHeight = localStorage.getItem('personalPrefer_height');
+  const parsedHeight =
+    storedHeight === null ? [165, 175] : JSON.parse(storedHeight);
+  const { rangeHandler: heightHandler, rangeValue: height } =
+    useRangeState(parsedHeight);
+  const [, setHeight] = useAtom(personalApplyAtoms.personalPrefer_height);
+
+  const storedStudentType = localStorage.getItem('personalPrefer_studentType');
+  const parsedStudentType =
+    storedStudentType === null ? [] : JSON.parse(storedStudentType);
+  const {
+    selectedValues: studentType,
+    select,
+    checkSelectedValues,
+  } = useToggleSelect<string>(3, parsedStudentType);
+  const [, setStudentType] = useAtom(
+    personalApplyAtoms.personalPrefer_studentType,
+  );
+
+  const setIsPageFinished = useSetAtom(pageFinishAtom);
+
+  useEffect(() => {
+    setAge(age.map(Number));
+    setHeight(height.map(Number));
+    setStudentType(studentType);
+    const isAllInputsFilled = age && height && studentType.length > 0;
+    setIsPageFinished(!!isAllInputsFilled);
+  }, [age, height, studentType]);
+
+  return (
+    <PageLayout.SingleCardBody
+      children={
+        <Paddler top={36} right={20} bottom={24} left={20}>
+          <Row>
+            <Col gap={56}>
+              <Col gap={28}>
+                <Col gap={12} align="center">
+                  <Text
+                    label={'1. 선호하는 상대의 나이를 선택해 주세요'}
+                    color={'Gray500'}
+                    typography={'NeoTitleM'}
+                    weight={400}
+                    size={18}
+                  />
+                  <Text
+                    label={'한국 나이(만 나이X) 기준으로 입력해주세요.'}
+                    color={'Secondary800'}
+                    typography={'GoThicBodyS'}
+                    weight={400}
+                    size={14}
+                  />
+                </Col>
+                <Col gap={32} align="center">
+                  <Text
+                    label={`${age[0]} - ${age[1]}세`}
+                    color={'Primary500'}
+                    typography={'LeferiBaseRegular'}
+                    weight={700}
+                    size={20}
+                  />
+                  {/* 슬라이더 수정 이후 패딩 값 수정*/}
+                  <Col padding="0 20px">
+                    <RangeSlider
+                      value={age}
+                      onChange={ageHandler}
+                      min={20}
+                      max={30}
+                      markStep={1}
+                      step={1}
+                      maxMarkPostfix="~"
+                    />
+                  </Col>
+                </Col>
+              </Col>
+
+              <Col gap={28} align="center">
+                <Text
+                  label={'2. 선호하는 상대의 키를 선택해 주세요'}
+                  color={'Gray500'}
+                  typography={'NeoTitleM'}
+                  weight={400}
+                  size={18}
+                />
+                <Col gap={32} align="center">
+                  <Text
+                    label={`${height[0]} - ${height[1]} cm`}
+                    color={'Primary500'}
+                    typography={'LeferiBaseRegular'}
+                    weight={700}
+                    size={20}
+                  />
+                  {/* 슬라이더 수정 이후 패딩 값 수정*/}
+                  <Col padding="0 20px">
+                    <RangeSlider
+                      value={height}
+                      onChange={heightHandler}
+                      min={150}
+                      max={190}
+                      markStep={5}
+                      step={5}
+                      minMarkPrefix="~"
+                      maxMarkPostfix="~"
+                    />
+                  </Col>
+                </Col>
+              </Col>
+
+              <Col gap={28}>
+                <Col gap={8} align="center">
+                  <Text
+                    label={'3. 선호하는 상대의 신분을 선택해 주세요'}
+                    color={'Gray500'}
+                    typography={'NeoTitleM'}
+                    weight={400}
+                    size={18}
+                  />
+                  <Text
+                    label={
+                      '복수 선택이 가능하며 무관한 경우 모두 선택해 주세요.'
+                    }
+                    color={'Secondary800'}
+                    typography={'GoThicBodyS'}
+                    weight={400}
+                    size={14}
+                  />
+                </Col>
+                <Col gap={8}>
+                  <RoundButton
+                    status={
+                      checkSelectedValues('학부생') ? 'active' : 'inactive'
+                    }
+                    label={'학부생'}
+                    height={56}
+                    onClick={() => select('학부생')()}
+                    borderType="primary"
+                  />
+                  <RoundButton
+                    status={
+                      checkSelectedValues('대학원생') ? 'active' : 'inactive'
+                    }
+                    label={'대학원생'}
+                    height={56}
+                    onClick={() => select('대학원생')()}
+                    borderType="primary"
+                  />
+                  <RoundButton
+                    status={
+                      checkSelectedValues('졸업생') ? 'active' : 'inactive'
+                    }
+                    label={'졸업생'}
+                    height={56}
+                    onClick={() => select('졸업생')()}
+                    borderType="primary"
+                  />
+                </Col>
+              </Col>
+            </Col>
+          </Row>
+        </Paddler>
+      }
+    />
+  );
 };
 
 export default FirstPage;

--- a/src/pages/personal/myPreferTypeStep/FirstPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/FirstPage.tsx
@@ -7,7 +7,7 @@ import RoundButton from '~/components/buttons/roundButton/RoundButton';
 import RangeSlider from '~/components/rangeSlider/RangeSlider';
 import useRangeState from '~/hooks/useRangeState';
 import { useEffect } from 'react';
-import { useAtom, useSetAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
 import { personalApplyAtoms } from '~/store/meeting';
 import { pageFinishAtom } from '~/store/funnel';
 import { useToggleSelect } from '~/hooks/useToggleSelect';
@@ -17,14 +17,14 @@ const FirstPage = () => {
   const parsedAge = storedAge === null ? [24, 27] : JSON.parse(storedAge);
   const { rangeHandler: ageHandler, rangeValue: age } =
     useRangeState(parsedAge);
-  const [, setAge] = useAtom(personalApplyAtoms.personalPrefer_age);
+  const setAge = useSetAtom(personalApplyAtoms.personalPrefer_age);
 
   const storedHeight = localStorage.getItem('personalPrefer_height');
   const parsedHeight =
     storedHeight === null ? [165, 175] : JSON.parse(storedHeight);
   const { rangeHandler: heightHandler, rangeValue: height } =
     useRangeState(parsedHeight);
-  const [, setHeight] = useAtom(personalApplyAtoms.personalPrefer_height);
+  const setHeight = useSetAtom(personalApplyAtoms.personalPrefer_height);
 
   const storedStudentType = localStorage.getItem('personalPrefer_studentType');
   const parsedStudentType =
@@ -34,7 +34,7 @@ const FirstPage = () => {
     select,
     checkSelectedValues,
   } = useToggleSelect<string>(3, parsedStudentType);
-  const [, setStudentType] = useAtom(
+  const setStudentType = useSetAtom(
     personalApplyAtoms.personalPrefer_studentType,
   );
 

--- a/src/pages/personal/myPreferTypeStep/ForthPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/ForthPage.tsx
@@ -1,5 +1,166 @@
+import PageLayout from '~/components/layout/page/PageLayout';
+import Paddler from '~/components/layout/Pad';
+import Col from '~/components/layout/Col';
+import Row from '~/components/layout/Row';
+import Text from '~/components/typography/Text';
+import MbtiButton from '~/components/buttons/mbtiButton/MbtiButton';
+import { useEffect } from 'react';
+import { useAtom, useSetAtom } from 'jotai';
+import { personalApplyAtoms } from '~/store/meeting';
+import { pageFinishAtom } from '~/store/funnel';
+import { useToggleSelect } from '~/hooks/useToggleSelect';
+
 const ForthPage = () => {
-  return <div>다섯 번쨰 페이지</div>;
+  const storedMbti = localStorage.getItem('personalInfo_mbti');
+  const parsedMbti = storedMbti === null ? [] : JSON.parse(storedMbti);
+  const {
+    selectedValues: mbti,
+    select: selectMbti,
+    checkSelectedValues: checkMbti,
+  } = useToggleSelect<string>(8, parsedMbti);
+  const [, setMbti] = useAtom(personalApplyAtoms.personalInfo_mbti);
+
+  const setIsPageFinished = useSetAtom(pageFinishAtom);
+
+  useEffect(() => {
+    setMbti(mbti);
+    const isAllInputsFilled =
+      (checkMbti('E') || checkMbti('I')) &&
+      (checkMbti('S') || checkMbti('N')) &&
+      (checkMbti('T') || checkMbti('F')) &&
+      (checkMbti('J') || checkMbti('P'));
+    setIsPageFinished(!!isAllInputsFilled);
+  }, [mbti]);
+
+  return (
+    <PageLayout.SingleCardBody
+      children={
+        <Paddler top={36} right={20} bottom={24} left={20}>
+          <Row>
+            <Col gap={32}>
+              <Col gap={8} align="center">
+                <Text
+                  label={'9. 선호하는 상대의 MBTI를 선택해 주세요'}
+                  color={'Gray500'}
+                  typography={'NeoTitleM'}
+                  weight={400}
+                  size={18}
+                />
+                <Col align="center">
+                  <Text
+                    label={'특정 MBTI를 선택하는 것이 아닌 선호하는 유형을'}
+                    color={'Secondary800'}
+                    typography={'PretendardRegular'}
+                    weight={400}
+                    size={14}
+                  />
+                  <Text
+                    label={'모두 선택해 주세요. (ex. S, N 중복 선택 가능)'}
+                    color={'Secondary800'}
+                    typography={'PretendardRegular'}
+                    weight={400}
+                    size={14}
+                  />
+                </Col>
+              </Col>
+              <Col gap={8}>
+                <Text
+                  label={'Q. 처음 보는 사람을 만났을 때 상대는'}
+                  color={'Secondary800'}
+                  typography={'PretendardRegular'}
+                  weight={400}
+                  size={14}
+                />
+                <Row gap={12}>
+                  <MbtiButton
+                    status={checkMbti('E') ? 'active' : 'inactive'}
+                    alphabet={'E'}
+                    label={'외향적'}
+                    onClick={() => selectMbti('E')()}
+                  />
+                  <MbtiButton
+                    status={checkMbti('I') ? 'active' : 'inactive'}
+                    alphabet={'I'}
+                    label={'내향적'}
+                    onClick={() => selectMbti('I')()}
+                  />
+                </Row>
+              </Col>
+              <Col gap={8}>
+                <Text
+                  label={'Q. 문제를 해결할 때 상대는'}
+                  color={'Secondary800'}
+                  typography={'PretendardRegular'}
+                  weight={400}
+                  size={14}
+                />
+                <Row gap={12}>
+                  <MbtiButton
+                    status={checkMbti('S') ? 'active' : 'inactive'}
+                    alphabet={'S'}
+                    label={'현실적'}
+                    onClick={() => selectMbti('S')()}
+                  />
+                  <MbtiButton
+                    status={checkMbti('N') ? 'active' : 'inactive'}
+                    alphabet={'N'}
+                    label={'직관적'}
+                    onClick={() => selectMbti('N')()}
+                  />
+                </Row>
+              </Col>
+              <Col gap={8}>
+                <Text
+                  label={'Q. 애인이 어려움에 처했을 때 상대는'}
+                  color={'Secondary800'}
+                  typography={'PretendardRegular'}
+                  weight={400}
+                  size={14}
+                />
+                <Row gap={12}>
+                  <MbtiButton
+                    status={checkMbti('T') ? 'active' : 'inactive'}
+                    alphabet={'T'}
+                    label={'이성적'}
+                    onClick={() => selectMbti('T')()}
+                  />
+                  <MbtiButton
+                    status={checkMbti('F') ? 'active' : 'inactive'}
+                    alphabet={'F'}
+                    label={'감성적'}
+                    onClick={() => selectMbti('F')()}
+                  />
+                </Row>
+              </Col>
+              <Col gap={8}>
+                <Text
+                  label={'Q. 데이트할 때 상대는'}
+                  color={'Secondary800'}
+                  typography={'PretendardRegular'}
+                  weight={400}
+                  size={14}
+                />
+                <Row gap={12}>
+                  <MbtiButton
+                    status={checkMbti('J') ? 'active' : 'inactive'}
+                    alphabet={'J'}
+                    label={'계획적'}
+                    onClick={() => selectMbti('J')()}
+                  />
+                  <MbtiButton
+                    status={checkMbti('P') ? 'active' : 'inactive'}
+                    alphabet={'P'}
+                    label={'즉흥적'}
+                    onClick={() => selectMbti('P')()}
+                  />
+                </Row>
+              </Col>
+            </Col>
+          </Row>
+        </Paddler>
+      }
+    />
+  );
 };
 
 export default ForthPage;

--- a/src/pages/personal/myPreferTypeStep/ForthPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/ForthPage.tsx
@@ -48,14 +48,9 @@ const ForthPage = () => {
                 />
                 <Col align="center">
                   <Text
-                    label={'특정 MBTI를 선택하는 것이 아닌 선호하는 유형을'}
-                    color={'Secondary800'}
-                    typography={'PretendardRegular'}
-                    weight={400}
-                    size={14}
-                  />
-                  <Text
-                    label={'모두 선택해 주세요. (ex. S, N 중복 선택 가능)'}
+                    label={
+                      '특정 MBTI를 선택하는 것이 아닌 선호하는 유형을 모두 선택해 주세요. (ex. S, N 중복 선택 가능)'
+                    }
                     color={'Secondary800'}
                     typography={'PretendardRegular'}
                     weight={400}

--- a/src/pages/personal/myPreferTypeStep/ForthPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/ForthPage.tsx
@@ -5,7 +5,7 @@ import Row from '~/components/layout/Row';
 import Text from '~/components/typography/Text';
 import MbtiButton from '~/components/buttons/mbtiButton/MbtiButton';
 import { useEffect } from 'react';
-import { useAtom, useSetAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
 import { personalApplyAtoms } from '~/store/meeting';
 import { pageFinishAtom } from '~/store/funnel';
 import { useToggleSelect } from '~/hooks/useToggleSelect';
@@ -18,7 +18,7 @@ const ForthPage = () => {
     select: selectMbti,
     checkSelectedValues: checkMbti,
   } = useToggleSelect<string>(8, parsedMbti);
-  const [, setMbti] = useAtom(personalApplyAtoms.personalInfo_mbti);
+  const setMbti = useSetAtom(personalApplyAtoms.personalInfo_mbti);
 
   const setIsPageFinished = useSetAtom(pageFinishAtom);
 
@@ -71,13 +71,13 @@ const ForthPage = () => {
                     status={checkMbti('E') ? 'active' : 'inactive'}
                     alphabet={'E'}
                     label={'외향적'}
-                    onClick={() => selectMbti('E')()}
+                    onClick={selectMbti('E')}
                   />
                   <MbtiButton
                     status={checkMbti('I') ? 'active' : 'inactive'}
                     alphabet={'I'}
                     label={'내향적'}
-                    onClick={() => selectMbti('I')()}
+                    onClick={selectMbti('I')}
                   />
                 </Row>
               </Col>
@@ -94,13 +94,13 @@ const ForthPage = () => {
                     status={checkMbti('S') ? 'active' : 'inactive'}
                     alphabet={'S'}
                     label={'현실적'}
-                    onClick={() => selectMbti('S')()}
+                    onClick={selectMbti('S')}
                   />
                   <MbtiButton
                     status={checkMbti('N') ? 'active' : 'inactive'}
                     alphabet={'N'}
                     label={'직관적'}
-                    onClick={() => selectMbti('N')()}
+                    onClick={selectMbti('N')}
                   />
                 </Row>
               </Col>
@@ -117,13 +117,13 @@ const ForthPage = () => {
                     status={checkMbti('T') ? 'active' : 'inactive'}
                     alphabet={'T'}
                     label={'이성적'}
-                    onClick={() => selectMbti('T')()}
+                    onClick={selectMbti('T')}
                   />
                   <MbtiButton
                     status={checkMbti('F') ? 'active' : 'inactive'}
                     alphabet={'F'}
                     label={'감성적'}
-                    onClick={() => selectMbti('F')()}
+                    onClick={selectMbti('F')}
                   />
                 </Row>
               </Col>
@@ -140,13 +140,13 @@ const ForthPage = () => {
                     status={checkMbti('J') ? 'active' : 'inactive'}
                     alphabet={'J'}
                     label={'계획적'}
-                    onClick={() => selectMbti('J')()}
+                    onClick={selectMbti('J')}
                   />
                   <MbtiButton
                     status={checkMbti('P') ? 'active' : 'inactive'}
                     alphabet={'P'}
                     label={'즉흥적'}
-                    onClick={() => selectMbti('P')()}
+                    onClick={selectMbti('P')}
                   />
                 </Row>
               </Col>

--- a/src/pages/personal/myPreferTypeStep/SecondPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/SecondPage.tsx
@@ -1,5 +1,277 @@
+import PageLayout from '~/components/layout/page/PageLayout';
+import Paddler from '~/components/layout/Pad';
+import Col from '~/components/layout/Col';
+import Row from '~/components/layout/Row';
+import Text from '~/components/typography/Text';
+import RoundButton from '~/components/buttons/roundButton/RoundButton';
+import RangeSlider from '~/components/rangeSlider/RangeSlider';
+import useRangeState from '~/hooks/useRangeState';
+import { useEffect } from 'react';
+import { useAtom, useSetAtom } from 'jotai';
+import { personalApplyAtoms } from '~/store/meeting';
+import { pageFinishAtom } from '~/store/funnel';
+import { useToggleSelect } from '~/hooks/useToggleSelect';
+
 const SecondPage = () => {
-  return <div>두 번쨰 페이지</div>;
+  const storedUniversity = localStorage.getItem('personalPrefer_univ');
+  const parsedUniversity =
+    storedUniversity === null ? [] : JSON.parse(storedUniversity);
+  const {
+    selectedValues: university,
+    select: selectUniversity,
+    checkSelectedValues: checkUniversity,
+  } = useToggleSelect<string>(3, parsedUniversity);
+  const [, setUniversity] = useAtom(personalApplyAtoms.personalPrefer_univ);
+
+  const storedReligion = localStorage.getItem('personalPrefer_religion');
+  const parsedReligion =
+    storedReligion === null ? [] : JSON.parse(storedReligion);
+  const {
+    selectedValues: religion,
+    select: selectReligion,
+    checkSelectedValues: checkReligion,
+  } = useToggleSelect<string>(6, parsedReligion);
+  const [, setReligion] = useAtom(personalApplyAtoms.personalPrefer_religion);
+
+  const [smoking, setSmoking] = useAtom(
+    personalApplyAtoms.personalPrefer_smoking,
+  );
+
+  const storedDrink = localStorage.getItem('personalPrefer_drink');
+  const parsedDrink = storedDrink === null ? [10, 17] : JSON.parse(storedDrink);
+  const { rangeHandler: drinkHandler, rangeValue: drink } =
+    useRangeState(parsedDrink);
+  const [, setDrink] = useAtom(personalApplyAtoms.personalPrefer_drink);
+
+  const setIsPageFinished = useSetAtom(pageFinishAtom);
+
+  useEffect(() => {
+    setUniversity(university);
+    setReligion(religion);
+    setDrink(drink.map(Number));
+    const isAllInputsFilled =
+      university.length > 0 && religion.length > 0 && smoking && drink;
+    setIsPageFinished(!!isAllInputsFilled);
+  }, [university, religion, smoking, drink]);
+
+  return (
+    <PageLayout.SingleCardBody
+      children={
+        <Paddler top={36} right={20} bottom={24} left={20}>
+          <Row>
+            <Col gap={56}>
+              <Col gap={28}>
+                <Col gap={12} align="center">
+                  <Text
+                    label={'4. 매칭을 원하는 대학을 선택해 주세요'}
+                    color={'Gray500'}
+                    typography={'NeoTitleM'}
+                    weight={400}
+                    size={18}
+                  />
+                  <Text
+                    label={
+                      '복수 선택이 가능하며 무관한 경우 모두 선택해 주세요.'
+                    }
+                    color={'Gray400'}
+                    typography={'GoThicBodyS'}
+                    weight={400}
+                    size={14}
+                  />
+                </Col>
+                <Col gap={8}>
+                  <RoundButton
+                    status={
+                      checkUniversity('경희대학교') ? 'active' : 'inactive'
+                    }
+                    label={'경희대학교'}
+                    height={56}
+                    onClick={() => selectUniversity('경희대학교')()}
+                    borderType="primary"
+                  />
+                  <RoundButton
+                    status={
+                      checkUniversity('서울시립대학교') ? 'active' : 'inactive'
+                    }
+                    label={'서울시립대학교'}
+                    height={56}
+                    onClick={() => selectUniversity('서울시립대학교')()}
+                    borderType="primary"
+                  />
+                  <RoundButton
+                    status={
+                      checkUniversity('한국외국어대학교')
+                        ? 'active'
+                        : 'inactive'
+                    }
+                    label={'한국외국어대학교'}
+                    height={56}
+                    onClick={() => selectUniversity('한국외국어대학교')()}
+                    borderType="primary"
+                  />
+                </Col>
+              </Col>
+
+              <Col gap={28}>
+                <Col gap={12} align="center">
+                  <Text
+                    label={'5. 선호하는 상대의 종교를 선택해 주세요'}
+                    color={'Gray500'}
+                    typography={'NeoTitleM'}
+                    weight={400}
+                    size={18}
+                  />
+                  <Text
+                    label={
+                      '복수 선택이 가능하며 무관한 경우 모두 선택해 주세요.'
+                    }
+                    color={'Gray400'}
+                    typography={'GoThicBodyS'}
+                    weight={400}
+                    size={14}
+                  />
+                </Col>
+                <Col gap={12}>
+                  <Row gap={12}>
+                    <RoundButton
+                      status={checkReligion('기독교') ? 'active' : 'inactive'}
+                      label={'기독교'}
+                      height={56}
+                      onClick={() => selectReligion('기독교')()}
+                      borderType="primary"
+                    />
+                    <RoundButton
+                      status={checkReligion('천주교') ? 'active' : 'inactive'}
+                      label={'천주교'}
+                      height={56}
+                      onClick={() => selectReligion('천주교')()}
+                      borderType="primary"
+                    />
+                  </Row>
+                  <Row gap={12}>
+                    <RoundButton
+                      status={checkReligion('불교') ? 'active' : 'inactive'}
+                      label={'불교'}
+                      height={56}
+                      onClick={() => selectReligion('불교')()}
+                      borderType="primary"
+                    />
+                    <RoundButton
+                      status={checkReligion('무교') ? 'active' : 'inactive'}
+                      label={'무교'}
+                      height={56}
+                      onClick={() => selectReligion('무교')()}
+                      borderType="primary"
+                    />
+                  </Row>
+                  <Row gap={12}>
+                    <RoundButton
+                      status={checkReligion('기타') ? 'active' : 'inactive'}
+                      label={'기타'}
+                      height={56}
+                      onClick={() => selectReligion('기타')()}
+                      borderType="primary"
+                    />
+                    <RoundButton
+                      status={
+                        checkReligion('상관 없어요!') ? 'active' : 'inactive'
+                      }
+                      label={'상관 없어요!'}
+                      height={56}
+                      onClick={() => selectReligion('상관 없어요!')()}
+                      borderType="primary"
+                    />
+                  </Row>
+                </Col>
+              </Col>
+
+              <Col gap={28}>
+                <Col align="center">
+                  <Text
+                    label={'6. 선호하는 상대의 흡연 여부를'}
+                    color={'Gray500'}
+                    typography={'NeoTitleM'}
+                    weight={400}
+                    size={18}
+                  />
+                  <Text
+                    label={'선택해 주세요'}
+                    color={'Gray500'}
+                    typography={'NeoTitleM'}
+                    weight={400}
+                    size={18}
+                  />
+                </Col>
+                <Col gap={8}>
+                  <RoundButton
+                    status={smoking === '흡연' ? 'active' : 'inactive'}
+                    label={'흡연'}
+                    height={56}
+                    onClick={() => setSmoking('흡연')}
+                    borderType="primary"
+                  />
+                  <RoundButton
+                    status={smoking === '비흡연' ? 'active' : 'inactive'}
+                    label={'비흡연'}
+                    height={56}
+                    onClick={() => setSmoking('비흡연')}
+                    borderType="primary"
+                  />
+                  <RoundButton
+                    status={smoking === '상관 없어요!' ? 'active' : 'inactive'}
+                    label={'상관 없어요!'}
+                    height={56}
+                    onClick={() => setSmoking('상관 없어요!')}
+                    borderType="primary"
+                  />
+                </Col>
+              </Col>
+
+              <Col gap={28}>
+                <Col align="center">
+                  <Text
+                    label={'7. 선호하는 상대의 한 달 기준'}
+                    color={'Gray500'}
+                    typography={'NeoTitleM'}
+                    weight={400}
+                    size={18}
+                  />
+                  <Text
+                    label={'음주 횟수를 선택해 주세요'}
+                    color={'Gray500'}
+                    typography={'NeoTitleM'}
+                    weight={400}
+                    size={18}
+                  />
+                </Col>
+                <Col gap={32} align="center">
+                  <Text
+                    label={`${drink[0]} - ${drink[1]} 회`}
+                    color={'Primary500'}
+                    typography={'LeferiBaseRegular'}
+                    weight={700}
+                    size={20}
+                  />
+                  {/* 슬라이더 수정 이후 패딩 값 수정*/}
+                  <Col padding="0 20px">
+                    <RangeSlider
+                      value={drink}
+                      onChange={drinkHandler}
+                      min={0}
+                      max={25}
+                      markStep={5}
+                      step={1}
+                      maxMarkPostfix="~"
+                    />
+                  </Col>
+                </Col>
+              </Col>
+            </Col>
+          </Row>
+        </Paddler>
+      }
+    />
+  );
 };
 
 export default SecondPage;

--- a/src/pages/personal/myPreferTypeStep/SecondPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/SecondPage.tsx
@@ -21,7 +21,7 @@ const SecondPage = () => {
     select: selectUniversity,
     checkSelectedValues: checkUniversity,
   } = useToggleSelect<string>(3, parsedUniversity);
-  const [, setUniversity] = useAtom(personalApplyAtoms.personalPrefer_univ);
+  const setUniversity = useSetAtom(personalApplyAtoms.personalPrefer_univ);
 
   const storedReligion = localStorage.getItem('personalPrefer_religion');
   const parsedReligion =
@@ -31,7 +31,7 @@ const SecondPage = () => {
     select: selectReligion,
     checkSelectedValues: checkReligion,
   } = useToggleSelect<string>(6, parsedReligion);
-  const [, setReligion] = useAtom(personalApplyAtoms.personalPrefer_religion);
+  const setReligion = useSetAtom(personalApplyAtoms.personalPrefer_religion);
 
   const [smoking, setSmoking] = useAtom(
     personalApplyAtoms.personalPrefer_smoking,
@@ -41,7 +41,7 @@ const SecondPage = () => {
   const parsedDrink = storedDrink === null ? [10, 17] : JSON.parse(storedDrink);
   const { rangeHandler: drinkHandler, rangeValue: drink } =
     useRangeState(parsedDrink);
-  const [, setDrink] = useAtom(personalApplyAtoms.personalPrefer_drink);
+  const setDrink = useSetAtom(personalApplyAtoms.personalPrefer_drink);
 
   const setIsPageFinished = useSetAtom(pageFinishAtom);
 

--- a/src/pages/personal/myPreferTypeStep/Step.tsx
+++ b/src/pages/personal/myPreferTypeStep/Step.tsx
@@ -1,7 +1,7 @@
 import { useFunnel } from '~/hooks/useFunnel';
 import FirstPage from './FirstPage';
 import SecondPage from './SecondPage';
-import ThirdPage from './ThirdPapge';
+import ThirdPage from './ThirdPage';
 import ForthPage from './ForthPage';
 import PageLayout from '~/components/layout/page/PageLayout';
 
@@ -10,8 +10,8 @@ const PAGE_NUMBER = [1, 2, 3, 4];
 const MyPreferTypeStep = () => {
   const { Funnel, currentPage, PageHandler } = useFunnel({
     pageNumberList: PAGE_NUMBER,
-    nextStep: { path: '/common/privacyPolicy' },
-    prevStep: { path: '/personal/myRomance' },
+    nextStep: { path: '/common/privacyPolicyStep' },
+    prevStep: { path: '/personal/myRomanceStep' },
   });
 
   return (

--- a/src/pages/personal/myPreferTypeStep/ThirdPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/ThirdPage.tsx
@@ -1,0 +1,75 @@
+import PageLayout from '~/components/layout/page/PageLayout';
+import Paddler from '~/components/layout/Pad';
+import Col from '~/components/layout/Col';
+import Row from '~/components/layout/Row';
+import Text from '~/components/typography/Text';
+import GridWrapper from '~/components/layout/gridWrapper/GridWrapper';
+import AnimalButton from '~/components/buttons/animalButton/AnimalButton';
+import { ANIMALS, ANIMALS_NAME } from '~/constants';
+import { useToggleSelect } from '~/hooks/useToggleSelect';
+import { useAtom, useSetAtom } from 'jotai';
+import { pageFinishAtom } from '~/store/funnel';
+import { useEffect } from 'react';
+import { personalApplyAtoms } from '~/store/meeting';
+
+const ThirdPage = () => {
+  const storedAnimal = localStorage.getItem('personalPrefer_animal');
+  const parsedAnimal = storedAnimal === null ? [] : JSON.parse(storedAnimal);
+  const {
+    selectedValues: animal,
+    select: selectAnimal,
+    checkSelectedValues: checkAnimal,
+  } = useToggleSelect<string>(9, parsedAnimal);
+  const [, setAnimal] = useAtom(personalApplyAtoms.personalPrefer_animal);
+  const setIsPageFinished = useSetAtom(pageFinishAtom);
+
+  useEffect(() => {
+    setAnimal(animal);
+    const isAllInputsFilled = animal.length > 0;
+    setIsPageFinished(!!isAllInputsFilled);
+  }, [animal]);
+
+  return (
+    <PageLayout.SingleCardBody
+      children={
+        <Paddler top={36} right={20} bottom={24} left={20}>
+          <Row>
+            <Col gap={32}>
+              <Col gap={12} align="center">
+                <Text
+                  label={'8. 선호하는 상대의 동물상을 선택해 주세요'}
+                  color={'Secondary900'}
+                  typography={'NeoTitleM'}
+                  weight={400}
+                  size={18}
+                />
+                <Col align="center">
+                  <Text
+                    label={'개수 상관없이 복수 선택이 가능해요'}
+                    color={'Secondary800'}
+                    typography={'PretendardRegular'}
+                    weight={400}
+                    size={14}
+                  />
+                </Col>
+              </Col>
+              <GridWrapper row={3} column={3} rowGap={16}>
+                {ANIMALS.map((animal, i) => (
+                  <AnimalButton
+                    key={i}
+                    animalType={animal}
+                    isActive={checkAnimal(animal)}
+                    label={ANIMALS_NAME[animal]}
+                    onMouseDown={selectAnimal(animal)}
+                  />
+                ))}
+              </GridWrapper>
+            </Col>
+          </Row>
+        </Paddler>
+      }
+    />
+  );
+};
+
+export default ThirdPage;

--- a/src/pages/personal/myPreferTypeStep/ThirdPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/ThirdPage.tsx
@@ -7,7 +7,7 @@ import GridWrapper from '~/components/layout/gridWrapper/GridWrapper';
 import AnimalButton from '~/components/buttons/animalButton/AnimalButton';
 import { ANIMALS, ANIMALS_NAME } from '~/constants';
 import { useToggleSelect } from '~/hooks/useToggleSelect';
-import { useAtom, useSetAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
 import { pageFinishAtom } from '~/store/funnel';
 import { useEffect } from 'react';
 import { personalApplyAtoms } from '~/store/meeting';
@@ -20,7 +20,7 @@ const ThirdPage = () => {
     select: selectAnimal,
     checkSelectedValues: checkAnimal,
   } = useToggleSelect<string>(9, parsedAnimal);
-  const [, setAnimal] = useAtom(personalApplyAtoms.personalPrefer_animal);
+  const setAnimal = useSetAtom(personalApplyAtoms.personalPrefer_animal);
   const setIsPageFinished = useSetAtom(pageFinishAtom);
 
   useEffect(() => {

--- a/src/pages/personal/myPreferTypeStep/ThirdPapge.tsx
+++ b/src/pages/personal/myPreferTypeStep/ThirdPapge.tsx
@@ -1,5 +1,0 @@
-const ThirdPage = () => {
-  return <div>세 번쨰 페이지</div>;
-};
-
-export default ThirdPage;

--- a/src/routes/personalRoutes.tsx
+++ b/src/routes/personalRoutes.tsx
@@ -12,7 +12,7 @@ const personalRoutes = [
     element: <MyRomanceStep />,
   },
   {
-    path: '/personal/mypPreferTypeStep',
+    path: '/personal/myPreferTypeStep',
     element: <MyPreferTypeStep />,
   },
 ];

--- a/src/store/meeting/personal.ts
+++ b/src/store/meeting/personal.ts
@@ -10,12 +10,12 @@ export type PersonalApplyInfo = {
   personalInfo_mbti: string[];
   personalInfo_interests: string[];
   personalInfo_question: ApplyQuestionArrType;
-  personalPrefer_age: string[];
-  personalPrefer_height: string[];
+  personalPrefer_age: number[];
+  personalPrefer_height: number[];
   personalPrefer_studentType: string[];
   personalPrefer_univ: string[];
-  personalPrefer_drink: string[];
-  personalPrefer_religion: string;
+  personalPrefer_drink: number[];
+  personalPrefer_religion: string[];
   personalPrefer_smoking: string;
   personalPrefer_animal: string[];
   personalPrefer_mbti: string[];
@@ -42,15 +42,15 @@ export const personalApplyAtoms: PesronalApplyAtoms = {
     { label: '', order: 3 },
     { label: '', order: 4 },
   ]),
-  personalPrefer_age: atomWithStorage('personalPrefer_age', ['']),
-  personalPrefer_height: atomWithStorage('personalPrefer_height', ['']),
+  personalPrefer_age: atomWithStorage<number[]>('personalPrefer_age', []),
+  personalPrefer_height: atomWithStorage<number[]>('personalPrefer_height', []),
   personalPrefer_studentType: atomWithStorage('personalPrefer_studentType', [
     '',
   ]),
   personalPrefer_univ: atomWithStorage('personalPrefer_univ', ['']),
   personalPrefer_smoking: atomWithStorage('personalPrefer_smoking', ''),
-  personalPrefer_religion: atomWithStorage('personalPrefer_religion', ''),
-  personalPrefer_drink: atomWithStorage('personalPrefer_drink', ['']),
+  personalPrefer_religion: atomWithStorage('personalPrefer_religion', ['']),
+  personalPrefer_drink: atomWithStorage<number[]>('personalPrefer_drink', []),
   personalPrefer_animal: atomWithStorage('personalPrefer_animal', ['']),
   personalPrefer_mbti: atomWithStorage('personalPrefer_mbti', ['']),
 };


### PR DESCRIPTION
### 1:1 "선호하는 상대 정보 입력하기" 페이지 구현

## 구현

- 1:1 "선호하는 상대 정보 입력하기" 페이지를 구현했습니다. 
<img width="400" src="https://github.com/uoslife/client-meeting-season4/assets/83596813/3ee7590b-39b5-4dcb-b524-076c8fc1801a">
<br/>

## 주의 사항
WEB-47, WEB-49 merge 상황에서는 제대로 동작하지 않습니다.
(MbtiButton 컴포넌트, useToggleSelect, personalRoutes 오타 수정 반영 안 되어 있음)

## TO-DO
- RangeSilder 수정 이후 gap, padding 값 수정