### PR TITLE
feat[WEB-67]: PF스타더스트 대체 글꼴 적용

### DIFF
--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import NeoDunggeunmoPro from '/fonts/NeoDunggeunmoPro-Regular.ttf';
-import PFstardust from '/fonts/PFstardust.ttf';
+import DOSGothic from '/fonts/DOSGothic.ttf';
 import PretendardRegular from '/fonts/Pretendard-Regular.ttf';
 import GothicA1Regular from '/fonts/GothicA1-Regular.ttf';
 import LeferiBaseRegular from '/fonts/LeferiBaseBold.ttf';
@@ -75,8 +75,8 @@ const reset = css`
     font-style: normal;
   }
   @font-face {
-    font-family: 'PFstardustType-Regular';
-    src: url(${PFstardust}) format('truetype');
+    font-family: 'DOSGothic-Regular';
+    src: url(${DOSGothic}) format('truetype');
     font-weight: normal;
     font-style: normal;
   }

--- a/src/styles/typographies.ts
+++ b/src/styles/typographies.ts
@@ -76,19 +76,19 @@ export const typographies = {
     font-size: 18px;
     line-height: 24px;
     font-weight: 500;
-    font-family: 'PFstardustType-Regular';
+    font-family: 'DOSGothic-Regular';
   `,
   PFLabelM: css`
     font-size: 14px;
     line-height: normal;
     font-weight: 400;
-    font-family: 'PFstardustType-Regular';
+    font-family: 'DOSGothic-Regular';
   `,
   PFLabelS: css`
     font-size: 12px;
     line-height: normal;
     font-weight: 400;
-    font-family: 'PFstardustType-Regular';
+    font-family: 'DOSGothic-Regular';
   `,
 
   // Pretendard


### PR DESCRIPTION
# PF스타더스트 대체 글꼴 적용

## 개요
- PF스타더스트 대체 글꼴로 DOSGothic을 적용했습니다.
- 기존에 적용했던 스타더스트 글꼴에 영향이 없도록, 변수명은 그대로 PF스타더스트로 유지했습니다. 사용하실 때는 PF스타더스트로 사용하시면 됩니다.