### PR TITLE
feat[WEB-69]: msw 기반 Axios api 추상화 작업

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@swc/plugin-emotion": "^2.5.116",
+    "axios": "^1.6.7",
     "immer": "^10.0.3",
     "jotai": "^2.6.4",
     "jotai-devtools": "^0.8.0",

--- a/src/api/core/index.ts
+++ b/src/api/core/index.ts
@@ -1,0 +1,44 @@
+import axios, { AxiosError } from 'axios';
+import { AuthAPI } from '~/api';
+
+const API = axios.create({
+  withCredentials: true,
+  baseURL: 'http://localhost:5173/',
+});
+
+API.interceptors.request.use(
+  res => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) return res;
+
+    res.headers.Authorization = `Bearer ${accessToken}`;
+    return res;
+  },
+  (error: AxiosError) => {
+    const statusCode = error.response?.status;
+    return Promise.reject(error);
+  },
+);
+
+API.interceptors.response.use(
+  res => {
+    return res;
+  },
+  async (error: AxiosError) => {
+    const originRequest = error;
+    const statusCode = error.response?.status;
+    if (statusCode === 401) {
+      const refreshToken = localStorage.getItem('refreshToken');
+      const res = await AuthAPI.getRefreshToken(refreshToken!);
+      localStorage.setItem('accessToken', res.data.data.accessToken);
+      localStorage.setItem('refreshToken', res.data.data.refreshToken);
+      axios.defaults.headers.common.Authorization = `Bearer ${res.data.data.accessToken}`;
+      originRequest.config!.headers.Authorization = `Bearer ${res.data.data.accessToken}`;
+      return axios(originRequest.config!);
+    }
+
+    // res.headers.Authorization = `Bearer ${accessToken}`;
+  },
+);
+
+export default API;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,7 @@
+import Auth from '~/api/services/auth';
+import Meeting from '~/api/services/meeting';
+import Payment from '~/api/services/payment';
+
+export const AuthAPI = Auth;
+export const MeetingAPI = Meeting;
+export const PaymentAPI = Payment;

--- a/src/api/services/auth.ts
+++ b/src/api/services/auth.ts
@@ -1,0 +1,27 @@
+import { ApiResponse, PromiseAxios } from '~/api/types';
+import API from '~/api/core';
+import type {
+  GetVerificationCodeRequest,
+  GetVerificationCodeResponse,
+  VerificationCodeCheckRequest,
+  VerificationCodeCheckResponse,
+} from '~/api/types/auth.type';
+
+const checkVerificationCode = async <T = VerificationCodeCheckResponse>(
+  data: VerificationCodeCheckRequest,
+): PromiseAxios<T> => {
+  return API.post<ApiResponse<T>>('/api/verification/check', data);
+};
+
+const getVerificationCode = async <T = GetVerificationCodeResponse>(
+  data: GetVerificationCodeRequest,
+): PromiseAxios<T> => {
+  return API.post<ApiResponse<T>>('/api/verification/send', data);
+};
+
+const getRefreshToken = async <T = VerificationCodeCheckResponse>(
+  data: string,
+): PromiseAxios<T> => {
+  return API.post<ApiResponse<T>>('/api/refreshToken', data);
+};
+export default { checkVerificationCode, getVerificationCode, getRefreshToken };

--- a/src/api/services/meeting.ts
+++ b/src/api/services/meeting.ts
@@ -1,0 +1,111 @@
+import { ApiResponse, PromiseAxios } from '~/api/types';
+import API from '~/api/core';
+import {
+  GetGroupStatusResponse,
+  GetMeetingInfoResponse,
+  GetUserResponse,
+  JoinGroupUserListResponse,
+  TeamType,
+  UpdateInfoRequest,
+  UpdatePreferRequest,
+  UpdateUserRequest,
+} from '~/api/types/user.type';
+
+// 유저 기본 정보(이름, 키, 카카오톡ID, 학과, 등)
+// 유저 기본 정보를 얻습니다.
+const getUser = async <T = GetUserResponse>(): PromiseAxios<T> => {
+  return API.get<ApiResponse<T>>('/api/user');
+};
+
+// 유저를 삭제합니다.
+const resetUser = async <T = object>(): PromiseAxios<T> => {
+  return API.put<ApiResponse<T>>('/api/user');
+};
+
+// 유저 기본 정보를 업데이트 합니다.
+const updateUser = async <T = object>(
+  data: UpdateUserRequest,
+): PromiseAxios<T> => {
+  return API.patch<ApiResponse<T>>('/api/user', data);
+};
+
+// 유저가 존재하는지 파악합니다.
+const checkUser = async <T = boolean>(email: string): PromiseAxios<T> => {
+  return API.get<ApiResponse<T>>('/api/user', { params: { email: email } });
+};
+
+// 공통
+// 팅(1:1 / 3:3)을 생성합니다.
+const createMeeting = async <T = string>(
+  teamType: TeamType,
+  isTeamLeader: boolean,
+  name?: string,
+): PromiseAxios<T> => {
+  return API.post<ApiResponse<T>>(
+    `/api/meeting/${teamType}/${isTeamLeader}/create?name=${name}`,
+  );
+};
+// 팅 정보를 업데이트합니다.
+const updateInfo = async <T = object>(
+  teamType: TeamType,
+  isTeamLeader: boolean,
+  data: UpdateInfoRequest,
+): PromiseAxios<T> => {
+  return API.put<ApiResponse<T>>(
+    `/api/meeting/${teamType}/${isTeamLeader}/info`,
+    data,
+  );
+};
+
+// 팅 선호 정보를 업데이트합니다.
+const updatePrefer = async <T = object>(
+  teamType: TeamType,
+  isTeamLeader: boolean,
+  data: UpdatePreferRequest,
+): PromiseAxios<T> => {
+  return API.put<ApiResponse<T>>(
+    `api/meeting/${teamType}/${isTeamLeader}`,
+    data,
+  );
+};
+
+// 팅의 모든 정보를 받아옵니다.
+const getMeetingInfo = async <T = GetMeetingInfoResponse>(
+  teamType: TeamType,
+): PromiseAxios<T> => {
+  return API.get<ApiResponse<T>>(`/api/meeting/${teamType}/application/info`);
+};
+
+// 그룹
+// 생성한 그룹에 입장합니다.
+const joinGroup = async <T = JoinGroupUserListResponse>(
+  teamType: TeamType,
+  code: string,
+  isJoin: boolean,
+): PromiseAxios<T> => {
+  return API.post<ApiResponse<T>>(
+    `/api/meeting/${teamType}/join/${code}?isJoin=${isJoin}`,
+  );
+};
+// 현재 입장한 팅원을 알려줍니다.
+const getGroupStatus = async <T = GetGroupStatusResponse>(
+  teamType: TeamType,
+  code: string,
+): PromiseAxios<T> => {
+  return API.get<ApiResponse<T>>(
+    `/api/meeting/${teamType}/join/${code}/user/list`,
+  );
+};
+
+export default {
+  getUser,
+  resetUser,
+  updateUser,
+  checkUser,
+  createMeeting,
+  updateInfo,
+  updatePrefer,
+  getMeetingInfo,
+  joinGroup,
+  getGroupStatus,
+};

--- a/src/api/services/payment.ts
+++ b/src/api/services/payment.ts
@@ -1,0 +1,40 @@
+import { ApiResponse, PromiseAxios } from '~/api/types';
+import API from '~/api/core';
+import {
+  CheckPaymentResponse,
+  PaymentRequest,
+  PaymentResponse,
+  RefundForNotMatchingResponse,
+  RefundPaymentResponse,
+} from '~/api/types/payment.type';
+
+const requestPayment = async <T = PaymentResponse>(
+  data: PaymentRequest,
+): PromiseAxios<T> => {
+  return API.post<ApiResponse<T>>('/api/payment/request', data);
+};
+
+const refundPayment = async <T = RefundPaymentResponse>(
+  id: number,
+): PromiseAxios<T> => {
+  return API.post<ApiResponse<T>>('/api/payment/refund', { id: id });
+};
+
+const refundPaymentFotNotMatching = async <
+  T = RefundForNotMatchingResponse,
+>(): PromiseAxios<T> => {
+  return API.post<ApiResponse<T>>('/api/payment/refund/match');
+};
+
+const checkPayment = async <T = CheckPaymentResponse>(
+  uid: string,
+): PromiseAxios<T> => {
+  return API.post<ApiResponse<T>>('/api/payment/check', { uid: uid });
+};
+
+export default {
+  requestPayment,
+  refundPayment,
+  refundPaymentFotNotMatching,
+  checkPayment,
+};

--- a/src/api/types/auth.type.ts
+++ b/src/api/types/auth.type.ts
@@ -1,0 +1,15 @@
+export type GetVerificationCodeRequest = {
+  email: string;
+  university: string;
+};
+export type GetVerificationCodeResponse = {
+  result: boolean;
+};
+export type VerificationCodeCheckRequest = {
+  code: string;
+} & GetVerificationCodeRequest;
+
+export type VerificationCodeCheckResponse = {
+  accessToken: string;
+  refreshToken: string;
+};

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -1,0 +1,9 @@
+import { AxiosResponse } from 'axios';
+
+export type ApiResponse<T> = {
+  statusCode: number;
+  message: string;
+  data: T;
+};
+
+export type PromiseAxios<T> = Promise<AxiosResponse<ApiResponse<T>>>;

--- a/src/api/types/payment.type.ts
+++ b/src/api/types/payment.type.ts
@@ -1,0 +1,26 @@
+export type PaymentRequest = {
+  pg: 'kakaopay' | 'tosspayments';
+  payMethod: 'card';
+};
+
+export type PaymentResponse = {
+  merchandUid: string;
+  price: number;
+  phoneNumber: string;
+};
+
+export type RefundPaymentResponse = {
+  cancelSuccess: boolean;
+  message: string;
+};
+
+export type RefundForNotMatchingResponse = {
+  successCount: number;
+  failedCount: number;
+  refundList: RefundPaymentResponse;
+};
+
+export type CheckPaymentResponse = {
+  paymentSuccess: boolean;
+  message: string;
+};

--- a/src/api/types/user.type.ts
+++ b/src/api/types/user.type.ts
@@ -1,0 +1,112 @@
+export type SpiritAnimalType = (
+  | 'DOG'
+  | 'CAT'
+  | 'RABBIT'
+  | 'FOX'
+  | 'BEAR'
+  | 'HAMSTER'
+  | 'MONKEY'
+  | 'DINOSAUR'
+  | 'CHICK'
+)[];
+
+export type InterestType = (
+  | 'BOOK'
+  | 'EXERCISE'
+  | 'GAME'
+  | 'TRAVEL'
+  | 'ANIMAL'
+  | 'MUSIC'
+  | 'DRAWING'
+  | 'MOVIE_DRAMA'
+  | 'FASHION'
+  | 'COOKING'
+)[];
+
+export type ReligionType =
+  | 'CHRISTIAN'
+  | 'CATHOLIC'
+  | 'BUDDHISM'
+  | 'NO_RELIGION'
+  | 'ETC'
+  | 'NO_MATTER';
+
+export type TeamType = 'SINGLE' | 'TRIPLE';
+
+export type GetUserResponse = {
+  name: string;
+  age: number;
+  height: number;
+  university: string;
+  department: string;
+  studentType: string;
+  kakaoTalkId: string;
+  smoking: string;
+  drinkingMin: number;
+  drinkingMax: number;
+  spiritAnimal: SpiritAnimalType;
+  mbti: string[];
+  interest: InterestType;
+};
+
+export type UpdateUserRequest = {
+  name: string;
+  age: number;
+  gender: 'MALE' | 'FEMALE';
+  height: number;
+  phoneNumber: string;
+  kakaoTalkId: string;
+  department: string;
+  studentType: 'UNDERGRADUATE' | 'POSTGRADUATE' | 'GRADUATE';
+  religion?: ReligionType;
+
+  smoking?: 'TRUE' | 'FALSE' | 'NOT_MATTER';
+  drinkingMin?: number;
+  drinkingMax?: number;
+  spiritAnimal?: SpiritAnimalType;
+  mbti?: string[];
+  interest?: InterestType;
+};
+
+export type UpdatePreferRequest = {
+  ageMin: number;
+  ageMax: number;
+  heightMin?: number;
+  heightMax?: number;
+  studentType?: ('UNDERGRADUATE' | 'POSTGRADUATE' | 'GRADUATE')[];
+  university: ('UOS' | 'KHU' | 'HUFS')[];
+  religion?: ReligionType;
+  smoking?: ('TRUE' | 'FALSE' | 'NOT_MATTER')[];
+  spiritAnimal?: SpiritAnimalType;
+  mbti?: string[];
+  mood?: 'ACTIVE' | 'CALM' | 'NOT_MATTER';
+};
+
+export type UpdateInfoRequest = {
+  question1?: object;
+  question2?: number;
+  question3?: number;
+  question4?: number;
+  question5?: number;
+};
+
+export type JoinGroupUserListResponse = {
+  teamName: string;
+  userList: Array<{
+    name: string;
+  }>;
+};
+
+export type GetGroupStatusResponse = {
+  teamName: string;
+  userList: Array<{
+    name: string;
+  }>;
+};
+
+export type GetMeetingInfoResponse = {
+  teamType: TeamType;
+  teamName?: string;
+} & GetUserResponse &
+  UpdateInfoRequest &
+  UpdatePreferRequest;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -37,15 +37,17 @@ const createTeam = () => {
 const joinTeam = () => {
   return HttpResponse.json(
     {
-      teamName: 'mock-팀이름',
-      userList: [
-        {
-          name: '시대생1',
-        },
-        {
-          name: '시대생2',
-        },
-      ],
+      data: {
+        teamName: 'mock-팀이름',
+        userList: [
+          {
+            name: '시대생1',
+          },
+          {
+            name: '시대생2',
+          },
+        ],
+      },
     },
     { status: 200 },
   );
@@ -53,21 +55,23 @@ const joinTeam = () => {
 const getTeamUserListOnPending = () => {
   return HttpResponse.json(
     {
-      teamName: 'mock-팀이름',
-      userList: [
-        {
-          name: '시대생1',
-        },
-        {
-          name: '시대생2',
-        },
-      ],
+      data: {
+        teamName: 'mock-팀이름',
+        userList: [
+          {
+            name: '시대생1',
+          },
+          {
+            name: '시대생2',
+          },
+        ],
+      },
     },
     { status: 200 },
   );
 };
 const getAllTeamInfo = () => {
-  return HttpResponse.json(팀전체정보, { status: 200 });
+  return HttpResponse.json({ data: 팀전체정보 }, { status: 200 });
 };
 const deleteTeam = () => {
   return HttpResponse.json({}, { status: 204 });
@@ -85,9 +89,11 @@ const paymentHandlers = () => {
 const requestPayment = () => {
   return HttpResponse.json(
     {
-      merchantUid: 'mock-merchant-uid',
-      price: 3000,
-      phoneNumber: '010-0000-0000',
+      data: {
+        merchantUid: 'mock-merchant-uid',
+        price: 3000,
+        phoneNumber: '010-0000-0000',
+      },
     },
     { status: 200 },
   );
@@ -95,8 +101,10 @@ const requestPayment = () => {
 const refundPayment = () => {
   return HttpResponse.json(
     {
-      cancelSuccess: true,
-      message: 'mock-message',
+      data: {
+        cancelSuccess: true,
+        message: 'mock-message',
+      },
     },
     { status: 200 },
   );
@@ -104,14 +112,16 @@ const refundPayment = () => {
 const canclePayment = () => {
   return HttpResponse.json(
     {
-      successCount: 0,
-      failedCount: 0,
-      refundList: [
-        {
-          cancelSuccess: true,
-          message: 'mock-message',
-        },
-      ],
+      data: {
+        successCount: 0,
+        failedCount: 0,
+        refundList: [
+          {
+            cancelSuccess: true,
+            message: 'mock-message',
+          },
+        ],
+      },
     },
     { status: 200 },
   );
@@ -119,8 +129,10 @@ const canclePayment = () => {
 const checkPayment = () => {
   return HttpResponse.json(
     {
-      paymentSuccess: true,
-      message: 'mock-message',
+      data: {
+        paymentSuccess: true,
+        message: 'mock-message',
+      },
     },
     { status: 200 },
   );
@@ -131,7 +143,7 @@ const matchingHandlers = () => {
 };
 
 const getMatchedTeamInfo = () => {
-  return HttpResponse.json(팀전체정보, { status: 200 });
+  return HttpResponse.json({ data: 팀전체정보 }, { status: 200 });
 };
 
 const verificationHandlers = () => {
@@ -142,14 +154,24 @@ const verificationHandlers = () => {
 };
 
 const sendVerificationMail = () => {
-  return HttpResponse.json({ success: true }, { status: 200 });
-};
-
-const checkVerificationCode = () => {
+  const accessToken = localStorage.getItem('accessToken');
   return HttpResponse.json(
     {
-      accessToken: 'access-token-mock',
-      refreshToken: 'refresh-token-mock',
+      data: {
+        success: true,
+      },
+    },
+    { status: accessToken ? 200 : 401 },
+  );
+};
+
+const checkVerificationCode = async () => {
+  return HttpResponse.json(
+    {
+      data: {
+        accessToken: 'access-token-mock',
+        refreshToken: 'refresh-token-mock',
+      },
     },
     { status: 200 },
   );
@@ -160,25 +182,28 @@ const userHandlers = () => {
     http.get('/api/user', getUser),
     http.put('/api/user', resetUser),
     http.post('/api/user', updateUser),
+    http.post('/api/refreshToken', getRefreshToken),
   ];
 };
 
 const getUser = () => {
   return HttpResponse.json(
     {
-      name: '이루매',
-      age: 24,
-      height: 170,
-      university: 'UOS',
-      department: '경제학과',
-      studentType: 'UNDERGRADUATE',
-      kakaoTalkId: 'kakaoId',
-      smoking: 'TRUE',
-      drinkingMin: 0,
-      drinkingMax: 0,
-      spiritAnimal: ['DOG'],
-      mbti: 'string',
-      interest: ['BOOK'],
+      data: {
+        name: '이루매',
+        age: 24,
+        height: 170,
+        university: 'UOS',
+        department: '경제학과',
+        studentType: 'UNDERGRADUATE',
+        kakaoTalkId: 'kakaoId',
+        smoking: 'TRUE',
+        drinkingMin: 0,
+        drinkingMax: 0,
+        spiritAnimal: ['DOG'],
+        mbti: 'string',
+        interest: ['BOOK'],
+      },
     },
     { status: 200 },
   );
@@ -190,6 +215,18 @@ const resetUser = () => {
 
 const updateUser = () => {
   return HttpResponse.json({}, { status: 200 });
+};
+
+const getRefreshToken = () => {
+  return HttpResponse.json(
+    {
+      data: {
+        accessToken: 'access-token-mock2',
+        refreshToken: 'refresh-token-mock2',
+      },
+    },
+    { status: 200 },
+  );
 };
 
 const 팀전체정보 = {

--- a/src/pages/common/univVerificationStep/ThirdPage.tsx
+++ b/src/pages/common/univVerificationStep/ThirdPage.tsx
@@ -9,6 +9,12 @@ import { useSetAtom } from 'jotai';
 import { pageFinishAtom } from '~/store/funnel';
 import TextInput from '~/components/inputs/textInput/TextInput';
 import Paddler from '~/components/layout/Pad';
+import axios from 'axios';
+import {
+  checkVerificationCode,
+  getVerificationCode,
+} from '~/api/services/auth';
+import { AuthAPI } from '~/api';
 
 const ThirdPage = () => {
   const storedUnivType = localStorage.getItem('univ_type');
@@ -33,13 +39,28 @@ const ThirdPage = () => {
     }
   };
   // 인증번호 확인 절차
-  const handleTryValidate = () => {
+  const handleTryValidate = async () => {
     if (inputValue) setTryValidate(true);
-    // 인증코드 api 부착
+    const res = await AuthAPI.getVerificationCode({
+      email: 'test1',
+      university: 'test1',
+    });
+    console.log(res);
   };
 
   // 인증번호 확인 절차
-  const handleValidate = () => {};
+  const handleValidate = async () => {
+    const res = await AuthAPI.checkVerificationCode({
+      code: 'test1',
+      email: 'test1@gmail.com',
+      university: 'KHU',
+    });
+    const result = res.data;
+    console.log(result);
+    setIsPageFinished(true);
+    localStorage.setItem('accessToken', result.data.accessToken);
+    localStorage.setItem('refreshToken', result.data.refreshToken);
+  };
 
   return (
     <Paddler top={36} right={20} bottom={24} left={20}>
@@ -106,8 +127,8 @@ const ThirdPage = () => {
                 onChange={handleValidateCodeValue}
               />
               <RoundButton
-                onClick={() => setIsPageFinished(true)}
-                status={'disabled'}
+                onClick={handleValidate}
+                status={validateCodeValue ? 'active' : 'disabled'}
                 borderType={'gray'}
                 height={44}
                 width={94}>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,4 +12,12 @@ export default defineConfig({
   resolve: {
     alias: [{ find: '~', replacement: '/src' }],
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5173/',
+        changeOrigin: true,
+      },
+    },
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,10 +1080,24 @@ asynciterator.prototype@^1.0.0:
   dependencies:
     has-symbols "^1.0.3"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
+axios@^1.6.7:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
+  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
+  dependencies:
+    follow-redirects "^1.15.4"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-plugin-macros@^3.1.0:
   version "3.1.0"
@@ -1234,6 +1248,13 @@ color@^3.2.1:
     color-convert "^1.9.3"
     color-string "^1.6.0"
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1308,6 +1329,11 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 detect-node-es@^1.1.0:
   version "1.1.0"
@@ -1707,12 +1733,26 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
+follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2337,6 +2377,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@9.0.3:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
@@ -2593,6 +2645,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
# msw 기반 Axios api 추상화 작업

## 개요
- Axios 라이브러리를 사용하여 백엔드 통신을 위한 api를 작업했습니다.
- Axios 인터셉터를 설정하여 jwt 인증 작업을 진행했습니다.
- api에 필요한 type은 백엔드의 스키마를 기반으로 작업했습니다.
- msw의 각 api reponse 구조를 변경했습니다.
- msw를 활용한 예시 페이지를 제작했습니다.

## 상세설명
- src/mocks/handlers
api를 요청하면 msw에서 이를 가로채 대신 response를 보내줍니다. 현재 백엔드 스키마를 기반으로 response 응답값을 설정했습니다. 하지만 백엔드 스키마가 확정인 상태가 아니기 때문에 reponse 응답값을 변경할 필요가 있을 수도 있습니다. 
하단 사진은 msw의 api response 값 예시입니다. reponse 값을 바꿀 필요가 있다면, src/mocks/handlers에서 바꿀 필요가 있는 api를 찾아서 직접 reponse 값을 바꿔주시면 됩니다.
<img width="276" alt="image" src="https://github.com/uoslife/client-meeting-season4/assets/89263598/9430f6a4-ee49-4411-8260-b8595619fa05">

## 주의사항
- 백엔드 스키마가 변경될 가능성이 있습니다.