### PR TITLE
feat[WEB-66]: useStepToGoBack 완성과 시범 적용

### DIFF
--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -4,6 +4,7 @@ import {
   ReactElement,
   ReactNode,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -45,58 +46,83 @@ export const useFunnel = ({
   const navigate = useNavigate();
   const LAST_PAGE = pageNumberList.length;
 
-  const FunnelComponent = ({ children }: FunnelProps) => {
-    // children 검증
-    const validChildren = Children.toArray(children)
-      // children이 ReactElement인지
-      .filter(isValidElement)
-      // pageNumber props가 pageNumberList에 있는지
-      .filter((childPage: ReactElement) =>
-        pageNumberList.includes(childPage.props.pageNumber),
-      );
+  const FunnelComponent = useMemo(
+    () =>
+      ({ children }: FunnelProps) => {
+        // children 검증
+        const validChildren = Children.toArray(children)
+          // children이 ReactElement인지
+          .filter(isValidElement)
+          // pageNumber props가 pageNumberList에 있는지
+          .filter((childPage: ReactElement) =>
+            pageNumberList.includes(childPage.props.pageNumber),
+          );
 
-    // currenPage state에 따라 현재 Page.
-    const targetPage = validChildren.find(
-      (child: ReactElement) => child.props.pageNumber === currentPage,
-    );
+        // currenPage state에 따라 현재 Page.
+        const targetPage = validChildren.find(
+          (child: ReactElement) => child.props.pageNumber === currentPage,
+        );
 
-    return <>{targetPage}</>;
-  };
+        return <>{targetPage}</>;
+      },
+    [currentPage, pageNumberList],
+  );
 
-  const PageComponent = ({ children }: PageProps) => {
-    return <>{children}</>;
-  };
+  const PageComponent = useMemo(
+    () =>
+      ({ children }: PageProps) => {
+        return <>{children}</>;
+      },
+    [],
+  );
 
-  const Funnel = Object.assign(FunnelComponent, {
-    Page: PageComponent,
-  });
+  const Funnel = useMemo(
+    () =>
+      Object.assign(FunnelComponent, {
+        Page: PageComponent,
+      }),
+    [FunnelComponent, PageComponent],
+  );
 
   //Footer 컴포넌트 버튼 로직
-  const PageHandler = {
-    // 앞으로 가기
-    onNext: () => {
-      setIsPageFinished(false);
-      if (currentPage === LAST_PAGE) {
-        setNavigateNextStep(true);
-        navigate(nextPath, { state: nextState });
-        return;
-      }
-      setCurrentPage(currentPage + 1);
-    },
-    // 뒤로 가기
-    onPrev: () => {
-      if (currentPage === 1) {
-        setNavigateNextStep(false);
-        navigate(prevPath, { state: prevState });
-        return;
-      }
-      setCurrentPage(currentPage - 1);
-    },
-  };
+  const PageHandler = useMemo(
+    () => ({
+      // 앞으로 가기
+      onNext: () => {
+        setIsPageFinished(false);
+        if (currentPage === LAST_PAGE) {
+          setNavigateNextStep(true);
+          navigate(nextPath, { state: nextState });
+          return;
+        }
+        setCurrentPage(currentPage + 1);
+      },
+      // 뒤로 가기
+      onPrev: () => {
+        if (currentPage === 1) {
+          setNavigateNextStep(false);
+          navigate(prevPath, { state: prevState });
+          return;
+        }
+        setCurrentPage(currentPage - 1);
+      },
+    }),
+    [
+      currentPage,
+      LAST_PAGE,
+      setNavigateNextStep,
+      setIsPageFinished,
+      navigate,
+      nextPath,
+      nextState,
+      prevPath,
+      prevState,
+    ],
+  );
 
   useEffect(() => {
     navigateNextStep ? setCurrentPage(1) : setCurrentPage(LAST_PAGE);
-  }, [navigateNextStep, setNavigateNextStep]);
+  }, [setNavigateNextStep, navigateNextStep, LAST_PAGE]);
 
   return {
     Funnel,

--- a/src/hooks/useStepToGoBack.ts
+++ b/src/hooks/useStepToGoBack.ts
@@ -56,7 +56,7 @@ export const useStepToGoBack = <Step extends keyof CombinedValidities>(
     return ret;
   };
 
-  const stepToGoBack = getStepToGoBackVariableName(step);
+  const stepToGoBack = getStepToGoBackVariableName(prevSteps[step]);
 
   if (stepToGoBack === null) return null;
 

--- a/src/hooks/useStepToGoBack.ts
+++ b/src/hooks/useStepToGoBack.ts
@@ -4,6 +4,9 @@ import {
   CombinedValidities,
   combinedValidatiesAtoms,
 } from '~/models';
+import { CommonPath } from '~/routes/commonRoutes';
+import { GroupPath } from '~/routes/groupRoutes';
+import { PersonalPath } from '~/routes/personalRoutes';
 
 // state가 필요한 이전 라우트를 나타내는 연결 리스트
 const prevSteps: {
@@ -32,23 +35,50 @@ const prevSteps: {
  */
 export const useStepToGoBack = <Step extends keyof CombinedValidities>(
   step: Step,
-) => {
+): null | CommonPath | PersonalPath | GroupPath => {
   const entireValidities = useAtomValue(combinedValidatiesAtoms);
 
-  const getStepToGoBack = (
-    recursiveFunctionParamStep: CombinedStep | null,
+  const getStepToGoBackVariableName = (
+    current: CombinedStep | null,
   ): CombinedStep | null => {
-    // base case: 최전의 step
-    if (recursiveFunctionParamStep === null) return null;
+    let ret: CombinedStep | null = null;
 
-    const isCurrentStepValid = Object.values(
-      entireValidities[recursiveFunctionParamStep],
-    ).every(Boolean);
+    while (current !== null) {
+      const isCurrentStepValid = Object.values(entireValidities[current]).every(
+        Boolean,
+      );
 
-    if (!isCurrentStepValid) return recursiveFunctionParamStep;
+      if (!isCurrentStepValid) ret = current;
 
-    return getStepToGoBack(prevSteps[recursiveFunctionParamStep]);
+      current = prevSteps[current];
+    }
+
+    return ret;
   };
 
-  return getStepToGoBack(prevSteps[step]);
+  const stepToGoBack = getStepToGoBackVariableName(step);
+
+  if (stepToGoBack === null) return null;
+
+  return variableNameToPathName[stepToGoBack];
+};
+
+const variableNameToPathName: {
+  [key in CombinedStep]: CommonPath | GroupPath | PersonalPath;
+} = {
+  commonBranchGatewayStep: '/common/branchGatewayStep',
+  commonUnivVerificationStep: '/common/univVerificationStep',
+  groupLeaderGroupCreateStep: '/group/leader/createStep',
+  groupLeaderGroupInformationStep: '/group/leader/groupInformationStep',
+  groupRoleSelectStep: '/group/roleSelectStep',
+  groupLeaderMyInformationStep: '/group/leader/myInformationStep',
+  groupLeaderPledgeStep: '/group/leader/pledgeStep',
+  groupLeaderPreferStep: '/group/leader/preferStep',
+  groupMemberMyInformationStep: '/group/member/myInformationStep',
+  groupMemberParticipateStep: '/group/member/participateStep',
+  groupMemberPledgeStep: '/group/member/pledgeStep',
+  personalMyInformationStep: '/personal/myInformationStep',
+  personalMyRomanceStep: '/personal/myRomanceStep',
+  personalPledgeStep: '/personal/pledgeStep',
+  personalPreferInfoStep: '/personal/myPreferTypeStep',
 };

--- a/src/pages/common/branchGatewayStep/Step.tsx
+++ b/src/pages/common/branchGatewayStep/Step.tsx
@@ -3,6 +3,8 @@ import { useFunnel } from '~/hooks/useFunnel';
 import FirstPage from './FirstPage';
 import { meetingTypeAtom } from '~/store/meeting';
 import { useAtomValue } from 'jotai';
+import { useStepToGoBack } from '~/hooks/useStepToGoBack';
+import useTypeSafeNavigate from '~/hooks/useTypeSafeNavigate';
 
 const CommonBranchGatewayStep = () => {
   const meetingTypeValue = useAtomValue(meetingTypeAtom);
@@ -18,6 +20,14 @@ const CommonBranchGatewayStep = () => {
       path: '/common/univVerificationStep',
     },
   });
+
+  const stepToGoBack = useStepToGoBack('commonBranchGatewayStep');
+  const navigate = useTypeSafeNavigate();
+
+  if (stepToGoBack) {
+    navigate(stepToGoBack);
+    return null;
+  }
 
   return (
     <PageLayout>

--- a/src/pages/common/univVerificationStep/Step.tsx
+++ b/src/pages/common/univVerificationStep/Step.tsx
@@ -3,6 +3,8 @@ import FirstPage from './FirstPage';
 import SecondPage from './SecondPage';
 import ThirdPage from './ThirdPage';
 import PageLayout from '~/components/layout/page/PageLayout';
+import { useStepToGoBack } from '~/hooks/useStepToGoBack';
+import useTypeSafeNavigate from '~/hooks/useTypeSafeNavigate';
 
 const PAGE_NUMBER = [1, 2, 3];
 
@@ -12,6 +14,14 @@ const CommonUnivVerificationStep = () => {
     nextStep: { path: '/common/branchGatewayStep' },
     prevStep: { path: '/common/landingStep' },
   });
+
+  const stepToGoBack = useStepToGoBack('commonUnivVerificationStep');
+  const navigate = useTypeSafeNavigate();
+
+  if (stepToGoBack) {
+    navigate(stepToGoBack);
+    return null;
+  }
 
   return (
     <PageLayout>

--- a/src/pages/personal/myInformationStep/Step.tsx
+++ b/src/pages/personal/myInformationStep/Step.tsx
@@ -7,6 +7,8 @@ import ForthPage from './ForthPage';
 import FifthPage from './FifthPage';
 import SixthPage from './SixthPage';
 import SeventhPage from './SeventhPage';
+import { useStepToGoBack } from '~/hooks/useStepToGoBack';
+import useTypeSafeNavigate from '~/hooks/useTypeSafeNavigate';
 
 const PAGE_NUMBER = [1, 2, 3, 4, 5, 6, 7];
 
@@ -16,6 +18,14 @@ const PersonalMyInformationStep = () => {
     prevStep: { path: '/common/branchGatewayStep' },
     nextStep: { path: '/personal/myRomanceStep' },
   });
+
+  const stepToGoBack = useStepToGoBack('personalMyInformationStep');
+  const navigate = useTypeSafeNavigate();
+
+  if (stepToGoBack) {
+    navigate(stepToGoBack);
+    return null;
+  }
 
   return (
     <PageLayout>


### PR DESCRIPTION
- 구현이 미흡했던 useStepToGoBack 작업을 완료하였습니다. 이제 개발에 사용 가능합니다.

# Interface Description

- parameter로는 현재 step을 받습니다.
![image](https://github.com/uoslife/client-meeting-season4/assets/97388599/3cfbc1d5-4959-4756-9e93-ea72609f3d44)
- 대충 이런 모양의 단일연결리스트 모델이 구현되어 있습니다. `src\hooks\useStepToGoBack.ts`의 `prevSteps` 객체에서 확인 가능합니다.
- 저 화살표 경로대로 이전 Step들을 조사해서 유효하지 않은 Step이 있으면 해당 Step을, 모든 이전 페이지가 유효하다면 null을 반환합니다.
- hook을 사용하는 페이지에서 해당 hook을 호출하고, 결과값이 not null이라면 결과값 step으로 강제로 navigate시켜주는 식으로 채워지지 않은 step으로 되돌려주는 UX를 구현할 수 있습니다..

# Use Example

- common/branchGatewatStep, common/univVerificationStep, personal/myInformationStep에 시범으로 적용되어 있습니다. 갖다 쓰실때 참고하시면 되겠습니다.
```tsx
  // src\pages\common\branchGatewayStep\Step.tsx, line 24~
  const stepToGoBack = useStepToGoBack('commonBranchGatewayStep');
  const navigate = useTypeSafeNavigate();

  if (stepToGoBack) {
    navigate(stepToGoBack);
    return null;
  }
```

# 이외 변경사항

- useFunnel가 반환하는 컴포넌트가, 상위 컴포넌트에서 리렌더링이 발생하면 언마운트-마운트가 계속 발생하는 이슈가 있어 useMemo를 걸어 개선하였습니다.