### PR TITLE
fix[WEB-78]: mbti type string[] -> string으로 변경

### DIFF
--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -47,8 +47,8 @@ export type InfoOptions = {
   smoking: null | SmokingOption;
   drinkRange: [number, number];
   animalOptions: AnimalOption[];
-  mbti: MBTIOption[];
-  mbtis: MBTIOption[][];
+  mbti: MBTIOption;
+  mbtis: MBTIOption;
   univs: Univ[];
   studentTypes: StudentOption[];
   interestOptions: interestKeyType[];

--- a/src/models/personal/data.ts
+++ b/src/models/personal/data.ts
@@ -24,7 +24,7 @@ export const personalInitialData: PersonalData = {
       animalOptions: [],
     },
     page5: {
-      mbti: [],
+      mbti: '',
     },
     page6: {
       interestOptions: [],
@@ -53,7 +53,7 @@ export const personalInitialData: PersonalData = {
       drinkRange: [1, 2],
     },
     page3: { animalOptions: [] },
-    page4: { mbtis: [[], [], [], []] },
+    page4: { mbtis: '' },
   },
   personalPledgeStep: {
     page1: {

--- a/src/models/personal/validation.ts
+++ b/src/models/personal/validation.ts
@@ -11,7 +11,14 @@ export const personalValidators: PersonalValidator = {
       kakaoId !== '' && phone !== '' && major !== '' && !!studentType,
     page3: ({ religion, smoking }) => !!religion && smoking !== null,
     page4: ({ animalOptions }) => animalOptions.length > 0,
-    page5: ({ mbti }) => !!mbti[0] && !!mbti[1] && !!mbti[2] && !!mbti[3],
+    page5: ({ mbti }) => {
+      return (
+        ['E', 'I'].some(prop => mbti.includes(prop)) &&
+        ['N', 'S'].some(prop => mbti.includes(prop)) &&
+        ['T', 'F'].some(prop => mbti.includes(prop)) &&
+        ['P', 'J'].some(prop => mbti.includes(prop))
+      );
+    },
     page6: ({ interestOptions }) => interestOptions.length === 3,
     page7: ({ message }) => message.length >= 10,
   },
@@ -30,7 +37,14 @@ export const personalValidators: PersonalValidator = {
     page2: ({ religionOptions, smoking, univs }) =>
       univs.length > 0 && religionOptions.length > 0 && smoking !== null,
     page3: ({ animalOptions }) => animalOptions.length > 0,
-    page4: ({ mbtis }) => mbtis.every(mbti => mbti.length > 0),
+    page4: ({ mbtis }) => {
+      return (
+        ['E', 'I'].some(prop => mbtis.includes(prop)) &&
+        ['N', 'S'].some(prop => mbtis.includes(prop)) &&
+        ['T', 'F'].some(prop => mbtis.includes(prop)) &&
+        ['P', 'J'].some(prop => mbtis.includes(prop))
+      );
+    },
   },
 };
 

--- a/src/models/personal/validation.ts
+++ b/src/models/personal/validation.ts
@@ -11,14 +11,11 @@ export const personalValidators: PersonalValidator = {
       kakaoId !== '' && phone !== '' && major !== '' && !!studentType,
     page3: ({ religion, smoking }) => !!religion && smoking !== null,
     page4: ({ animalOptions }) => animalOptions.length > 0,
-    page5: ({ mbti }) => {
-      return (
-        ['E', 'I'].some(prop => mbti.includes(prop)) &&
-        ['N', 'S'].some(prop => mbti.includes(prop)) &&
-        ['T', 'F'].some(prop => mbti.includes(prop)) &&
-        ['P', 'J'].some(prop => mbti.includes(prop))
-      );
-    },
+    page5: ({ mbti }) =>
+      ['E', 'I'].some(prop => mbti.includes(prop)) &&
+      ['N', 'S'].some(prop => mbti.includes(prop)) &&
+      ['T', 'F'].some(prop => mbti.includes(prop)) &&
+      ['P', 'J'].some(prop => mbti.includes(prop)),
     page6: ({ interestOptions }) => interestOptions.length === 3,
     page7: ({ message }) => message.length >= 10,
   },

--- a/src/pages/personal/myInformationStep/FifthPage.tsx
+++ b/src/pages/personal/myInformationStep/FifthPage.tsx
@@ -21,14 +21,23 @@ const Fifthpage = () => {
   const onClickMbtiButton = (value: string) => () => {
     setPageState(prev => {
       let newMbtis = prev.mbti;
-      if (['E', 'I'].includes(value)) {
-        newMbtis = newMbtis.replace(/[EI]/g, '');
-      } else if (['N', 'S'].includes(value)) {
-        newMbtis = newMbtis.replace(/[NS]/g, '');
-      } else if (['T', 'F'].includes(value)) {
-        newMbtis = newMbtis.replace(/[TF]/g, '');
-      } else if (['P', 'J'].includes(value)) {
-        newMbtis = newMbtis.replace(/[PJ]/g, '');
+      switch (value) {
+        case 'E':
+        case 'I':
+          newMbtis = newMbtis.replace(/[EI]/g, '');
+          break;
+        case 'N':
+        case 'S':
+          newMbtis = newMbtis.replace(/[NS]/g, '');
+          break;
+        case 'T':
+        case 'F':
+          newMbtis = newMbtis.replace(/[TF]/g, '');
+          break;
+        case 'P':
+        case 'J':
+          newMbtis = newMbtis.replace(/[PJ]/g, '');
+          break;
       }
       newMbtis += value;
       return { mbti: newMbtis };

--- a/src/pages/personal/myInformationStep/FifthPage.tsx
+++ b/src/pages/personal/myInformationStep/FifthPage.tsx
@@ -16,10 +16,23 @@ const Fifthpage = () => {
 
   const { mbti } = pageState;
 
-  const updateMbti = (order: number, itemValue: string) => {
-    const newMbtiState = [...mbti];
-    newMbtiState[order] = itemValue;
-    setPageState(prev => ({ ...prev, mbti: newMbtiState }));
+  const getMbtiStatus = (value: string): 'active' | 'inactive' =>
+    mbti.includes(value) ? 'active' : 'inactive';
+  const onClickMbtiButton = (value: string) => () => {
+    setPageState(prev => {
+      let newMbtis = prev.mbti;
+      if (['E', 'I'].includes(value)) {
+        newMbtis = newMbtis.replace(/[EI]/g, '');
+      } else if (['N', 'S'].includes(value)) {
+        newMbtis = newMbtis.replace(/[NS]/g, '');
+      } else if (['T', 'F'].includes(value)) {
+        newMbtis = newMbtis.replace(/[TF]/g, '');
+      } else if (['P', 'J'].includes(value)) {
+        newMbtis = newMbtis.replace(/[PJ]/g, '');
+      }
+      newMbtis += value;
+      return { mbti: newMbtis };
+    });
   };
 
   const pageValidity = useAtomValue(combinedValidatiesAtoms)
@@ -52,16 +65,16 @@ const Fifthpage = () => {
                 />
                 <Row gap={12}>
                   <MbtiButton
-                    status={mbti[0] === 'E' ? 'active' : 'inactive'}
+                    status={getMbtiStatus('E')}
                     alphabet={'E'}
                     label={'외향적'}
-                    onClick={() => updateMbti(0, 'E')}
+                    onClick={onClickMbtiButton('E')}
                   />
                   <MbtiButton
-                    status={mbti[0] === 'I' ? 'active' : 'inactive'}
+                    status={getMbtiStatus('I')}
                     alphabet={'I'}
                     label={'내향적'}
-                    onClick={() => updateMbti(0, 'I')}
+                    onClick={onClickMbtiButton('I')}
                   />
                 </Row>
               </Col>
@@ -75,16 +88,16 @@ const Fifthpage = () => {
                 />
                 <Row gap={12}>
                   <MbtiButton
-                    status={mbti[1] === 'S' ? 'active' : 'inactive'}
+                    status={getMbtiStatus('S')}
                     alphabet={'S'}
                     label={'현실적'}
-                    onClick={() => updateMbti(1, 'S')}
+                    onClick={onClickMbtiButton('S')}
                   />
                   <MbtiButton
-                    status={mbti[1] === 'N' ? 'active' : 'inactive'}
+                    status={getMbtiStatus('N')}
                     alphabet={'N'}
                     label={'직관적'}
-                    onClick={() => updateMbti(1, 'N')}
+                    onClick={onClickMbtiButton('N')}
                   />
                 </Row>
               </Col>
@@ -98,16 +111,16 @@ const Fifthpage = () => {
                 />
                 <Row gap={12}>
                   <MbtiButton
-                    status={mbti[2] === 'T' ? 'active' : 'inactive'}
+                    status={getMbtiStatus('T')}
                     alphabet={'T'}
                     label={'이성적'}
-                    onClick={() => updateMbti(2, 'T')}
+                    onClick={onClickMbtiButton('T')}
                   />
                   <MbtiButton
-                    status={mbti[2] === 'F' ? 'active' : 'inactive'}
+                    status={getMbtiStatus('F')}
                     alphabet={'F'}
                     label={'감성적'}
-                    onClick={() => updateMbti(2, 'F')}
+                    onClick={onClickMbtiButton('F')}
                   />
                 </Row>
               </Col>
@@ -121,16 +134,16 @@ const Fifthpage = () => {
                 />
                 <Row gap={12}>
                   <MbtiButton
-                    status={mbti[3] === 'J' ? 'active' : 'inactive'}
+                    status={getMbtiStatus('J')}
                     alphabet={'J'}
                     label={'계획적'}
-                    onClick={() => updateMbti(3, 'J')}
+                    onClick={onClickMbtiButton('J')}
                   />
                   <MbtiButton
-                    status={mbti[3] === 'P' ? 'active' : 'inactive'}
+                    status={getMbtiStatus('P')}
                     alphabet={'P'}
                     label={'즉흥적'}
-                    onClick={() => updateMbti(3, 'P')}
+                    onClick={onClickMbtiButton('P')}
                   />
                 </Row>
               </Col>

--- a/src/pages/personal/myPreferTypeStep/ForthPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/ForthPage.tsx
@@ -13,7 +13,6 @@ const ForthPage = () => {
   const [pageState, setPageState] = useAtom(
     personalDataAtoms.personalPreferInfoStep.page4,
   );
-  console.log(pageState);
 
   const { mbtis } = pageState;
 

--- a/src/pages/personal/myPreferTypeStep/ForthPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/ForthPage.tsx
@@ -13,6 +13,7 @@ const ForthPage = () => {
   const [pageState, setPageState] = useAtom(
     personalDataAtoms.personalPreferInfoStep.page4,
   );
+  console.log(pageState);
 
   const { mbtis } = pageState;
 
@@ -21,20 +22,19 @@ const ForthPage = () => {
     .personalPreferInfoStep.page4;
   setIsPageFinished(!!pageValidity);
 
-  const getMbtiStatus = (
-    index: number,
-    value: string,
-  ): 'active' | 'inactive' =>
-    mbtis[index].includes(value) ? 'active' : 'inactive';
-  const onClickMbtiButton = (index: number, value: string) => () =>
+  const getMbtiStatus = (value: string): 'active' | 'inactive' =>
+    mbtis.includes(value) ? 'active' : 'inactive';
+  const onClickMbtiButton = (value: string) => () => {
     setPageState(prev => {
-      const newMbtis = prev.mbtis[index].includes(value)
-        ? prev.mbtis.map((mbti, i) =>
-            i === index ? mbti.filter(m => m !== value) : mbti,
-          )
-        : prev.mbtis.map((mbti, i) => (i === index ? [...mbti, value] : mbti));
-      return { ...prev, mbtis: newMbtis };
+      let newMbtis = prev.mbtis;
+      if (newMbtis.includes(value)) {
+        newMbtis = newMbtis.replace(value, '');
+      } else {
+        newMbtis += value;
+      }
+      return { mbtis: newMbtis };
     });
+  };
 
   return (
     <PageLayout.SingleCardBody
@@ -72,16 +72,16 @@ const ForthPage = () => {
                 />
                 <Row gap={12}>
                   <MbtiButton
-                    status={getMbtiStatus(0, 'E')}
+                    status={getMbtiStatus('E')}
                     alphabet={'E'}
                     label={'외향적'}
-                    onClick={onClickMbtiButton(0, 'E')}
+                    onClick={onClickMbtiButton('E')}
                   />
                   <MbtiButton
-                    status={getMbtiStatus(0, 'I')}
+                    status={getMbtiStatus('I')}
                     alphabet={'I'}
                     label={'내향적'}
-                    onClick={onClickMbtiButton(0, 'I')}
+                    onClick={onClickMbtiButton('I')}
                   />
                 </Row>
               </Col>
@@ -95,16 +95,16 @@ const ForthPage = () => {
                 />
                 <Row gap={12}>
                   <MbtiButton
-                    status={getMbtiStatus(1, 'S')}
+                    status={getMbtiStatus('S')}
                     alphabet={'S'}
                     label={'현실적'}
-                    onClick={onClickMbtiButton(1, 'S')}
+                    onClick={onClickMbtiButton('S')}
                   />
                   <MbtiButton
-                    status={getMbtiStatus(1, 'N')}
+                    status={getMbtiStatus('N')}
                     alphabet={'N'}
                     label={'직관적'}
-                    onClick={onClickMbtiButton(1, 'N')}
+                    onClick={onClickMbtiButton('N')}
                   />
                 </Row>
               </Col>
@@ -118,16 +118,16 @@ const ForthPage = () => {
                 />
                 <Row gap={12}>
                   <MbtiButton
-                    status={getMbtiStatus(2, 'T')}
+                    status={getMbtiStatus('T')}
                     alphabet={'T'}
                     label={'이성적'}
-                    onClick={onClickMbtiButton(2, 'T')}
+                    onClick={onClickMbtiButton('T')}
                   />
                   <MbtiButton
-                    status={getMbtiStatus(2, 'F')}
+                    status={getMbtiStatus('F')}
                     alphabet={'F'}
                     label={'감성적'}
-                    onClick={onClickMbtiButton(2, 'F')}
+                    onClick={onClickMbtiButton('F')}
                   />
                 </Row>
               </Col>
@@ -141,16 +141,16 @@ const ForthPage = () => {
                 />
                 <Row gap={12}>
                   <MbtiButton
-                    status={getMbtiStatus(3, 'J')}
+                    status={getMbtiStatus('J')}
                     alphabet={'J'}
                     label={'계획적'}
-                    onClick={onClickMbtiButton(3, 'J')}
+                    onClick={onClickMbtiButton('J')}
                   />
                   <MbtiButton
-                    status={getMbtiStatus(3, 'P')}
+                    status={getMbtiStatus('P')}
                     alphabet={'P'}
                     label={'즉흥적'}
-                    onClick={onClickMbtiButton(3, 'P')}
+                    onClick={onClickMbtiButton('P')}
                   />
                 </Row>
               </Col>


### PR DESCRIPTION
## 수정 사항
mbti 타입이 기존 array로 구성되어 있던 것을 string으로 변경했습니다.

![image](https://github.com/uoslife/client-meeting-season4/assets/83596813/8d585c74-9c41-4f8e-85f7-c6eb54783d27)
![image](https://github.com/uoslife/client-meeting-season4/assets/83596813/3b1d34e8-08eb-4da0-874c-b8a20cba62dc)

## 추가 사항
- 자신의 mbti 입력 창은 EI, NS, TF, JP 중 하나씩만 선택하도록 막아두었습니다.
- 상대방의 선호 mbti 입력 창은 중복으로 선택을 허용해놓고 EI, NS, TF, JP 중 하나 이상을 선택해야 넘어가도록 막아두었습니다.

## 논의 사항
현재 mbti 순서가 뒤죽박죽인데 결과 페이지에서 자신의 mbti와 상대방의 선호 mbti를 띄우는 창에서 순서대로 정렬할 수 있게 하는 것이 가능한지