### PR TITLE
fix[WEB-79]: DropdownInput 초기값 null로 수정

### DIFF
--- a/src/models/group/data.ts
+++ b/src/models/group/data.ts
@@ -19,7 +19,7 @@ export const groupInitialData: GroupData = {
     page1: {
       name: '',
       gender: null,
-      age: '20',
+      age: '',
     },
     page2: {
       kakaoId: '',

--- a/src/models/personal/data.ts
+++ b/src/models/personal/data.ts
@@ -6,8 +6,8 @@ export const personalInitialData: PersonalData = {
     page1: {
       name: '',
       gender: null,
-      age: '20',
-      height: '180',
+      age: '',
+      height: '',
     },
     page2: {
       kakaoId: '',


### PR DESCRIPTION
## 수정 사항
DropdownInput 컴포넌트가 쓰인 페이지들 초기값이 설정되어 선택하지 않아도 버튼이 활성화되는 문제가 발생하여 해당 페이지들 초기값을 삭제했습니다.


<img width="200" src="https://github.com/uoslife/client-meeting-season4/assets/83596813/28347fdb-f65d-4b3c-9704-261da139d07a">
<img width="200" src="https://github.com/uoslife/client-meeting-season4/assets/83596813/da09c04b-f446-403a-b921-435ffcbb5b67">


## 논의 사항
- "나이 선택", "키 선택"이라는 워딩 말고 "나이를 선택해 주세요." 이런 식으로 변경할지 논의