### PR TITLE
fix[WEB-92]: 1:1 "선호하는 상대 정보 입력하기" 페이지 종교 버튼 수정

### DIFF
--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -6,13 +6,7 @@ export type GenderOption = 'F' | 'M';
 
 export type StudentOption = '학부생' | '대학원생' | '졸업생';
 
-export type ReligionOption =
-  | '기독교'
-  | '천주교'
-  | '불교'
-  | '무교'
-  | '기타'
-  | '상관 없어요!';
+export type ReligionOption = '기독교' | '천주교' | '불교' | '무교' | '기타';
 
 export type SmokingOption = '흡연' | '비흡연' | '상관 없어요!';
 

--- a/src/pages/personal/myPreferTypeStep/SecondPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/SecondPage.tsx
@@ -10,6 +10,7 @@ import { pageFinishAtom } from '~/models/funnel';
 import { personalDataAtoms } from '~/models/personal/data';
 import { combinedValidatiesAtoms } from '~/models';
 import { ReligionOption, Univ } from '~/models/options';
+import { css } from '@emotion/react';
 
 const SecondPage = () => {
   const [pageState, setPageState] = useAtom(
@@ -154,12 +155,10 @@ const SecondPage = () => {
                       height={56}
                       borderType="primary"
                     />
-                    <RoundButton
-                      status={getReligionButtonStatus('상관 없어요!')}
-                      onClick={onClickReligionButton('상관 없어요!')}
-                      label={'상관 없어요!'}
-                      height={56}
-                      borderType="primary"
+                    <div
+                      css={css`
+                        width: 100%;
+                      `}
                     />
                   </Row>
                 </Col>


### PR DESCRIPTION
## 1:1 "선호하는 상대 정보 입력하기" 페이지 종교 버튼 수정

## 수정

- “1:1 "선호하는 상대 정보 입력하기" 페이지 종교 버튼 중 중복 선택이 가능함에도 불구하고 "상관 없어요!" 버튼이 있어 해당 버튼을 삭제했습니다. (피그마에서 요청 받은 내용)
<img width="300" src="https://github.com/uoslife/client-meeting-season4/assets/83596813/35faaa0c-aae4-4b6b-8d19-b017a2b4b6a2">
<br/>