### PR TITLE
fix[WEB-85]: 시대팅 이용 서약 페이지 check 범위 수정 및 align left 설정

### DIFF
--- a/src/components/pledgeItem/PledgeItem.tsx
+++ b/src/components/pledgeItem/PledgeItem.tsx
@@ -17,6 +17,7 @@ const PledgeItem = ({
   onClick?: () => void;
 }) => (
   <Col
+    onClick={onClick}
     padding="20px"
     style={{
       backgroundColor: `${colors['Gray000']}`,
@@ -29,17 +30,20 @@ const PledgeItem = ({
         css={css`
           width: calc(100% - 36px);
         `}>
-        <Text label={title} color={'Gray500'} typography={'GoThicTitleS'} />
+        <Text
+          label={title}
+          color={'Gray500'}
+          typography={'GoThicTitleS'}
+          align="left"
+        />
         <Text
           label={content}
           color={'Gray500'}
           typography={'GoThicBodyS'}
-          css={css`
-            text-align: start;
-          `}
+          align="left"
         />
       </Col>
-      <Checkbox checked={checked} onClick={onClick} />
+      <Checkbox checked={checked} />
     </Row>
   </Col>
 );


### PR DESCRIPTION
- 각 이용 서약에 대해 선택 범위를 checkbox에서 PledgeItem으로 수정하였습니다
- text 기본값인 text-align: "center"에서 요구사항에 맞게 "left"로 수정하였습니다
<img width="238" alt="image" src="https://github.com/uoslife/client-meeting-season4/assets/81912837/6145fd89-013b-4bfb-b5af-ff9ffc1de853">
