### PR TITLE
[WEB-82] 보안서약 페이지에 Checkbox 추가

### DIFF
--- a/src/components/pledgeItem/PledgeItem.tsx
+++ b/src/components/pledgeItem/PledgeItem.tsx
@@ -11,8 +11,8 @@ const PledgeItem = ({
   checked,
   onClick,
 }: {
-  title: string;
-  content: string;
+  title?: string;
+  content?: string;
   checked: boolean;
   onClick?: () => void;
 }) => (
@@ -30,18 +30,22 @@ const PledgeItem = ({
         css={css`
           width: calc(100% - 36px);
         `}>
-        <Text
-          label={title}
-          color={'Gray500'}
-          typography={'GoThicTitleS'}
-          align="left"
-        />
-        <Text
-          label={content}
-          color={'Gray500'}
-          typography={'GoThicBodyS'}
-          align="left"
-        />
+        {title && (
+          <Text
+            label={title}
+            color={'Gray500'}
+            typography={'GoThicTitleS'}
+            align="left"
+          />
+        )}
+        {content && (
+          <Text
+            label={content}
+            color={'Gray500'}
+            typography={'GoThicBodyS'}
+            align="left"
+          />
+        )}
       </Col>
       <Checkbox checked={checked} />
     </Row>

--- a/src/models/common/validation.ts
+++ b/src/models/common/validation.ts
@@ -7,7 +7,7 @@ export const commonValidators: CommonValidator = {
   commonUnivVerificationStep: {
     page1: ({ univType }) => !!univType,
     // page2: ({ checked }) => checked.every(Boolean),
-    page2: () => true, // temp
+    page2: ({ checked }) => checked.every(Boolean),
     page3: () => true, // temp
   },
   commonBranchGatewayStep: {

--- a/src/pages/common/univVerificationStep/SecondPage.tsx
+++ b/src/pages/common/univVerificationStep/SecondPage.tsx
@@ -8,9 +8,10 @@ import Text from '~/components/typography/Text';
 import { css } from '@emotion/react';
 import { commonDataAtoms } from '~/models/common/data';
 import { combinedValidatiesAtoms } from '~/models';
+import PledgeItem from '~/components/pledgeItem/PledgeItem';
 
 const SecondPage = () => {
-  const [, setPageState] = useAtom(
+  const [pageState, setPageState] = useAtom(
     commonDataAtoms.commonUnivVerificationStep.page2,
   );
 
@@ -22,8 +23,6 @@ const SecondPage = () => {
   useEffect(() => {
     setPageState({ checked: [true, true] });
   }, [setPageState]);
-
-  // TODO: 체크 컴포넌트
 
   return (
     <Paddler top={36} right={20} bottom={24} left={20}>
@@ -60,6 +59,28 @@ const SecondPage = () => {
               css={css`
                 text-align: center;
               `}
+            />
+          </Col>
+          <Col gap={23} align="center">
+            <PledgeItem
+              title={
+                '타인에게 나의 웹메일, 카카오톡 ID, 전화번호를 양도하지 않을게요.'
+              }
+              checked={pageState.checked[0]}
+              onClick={() =>
+                setPageState(prev => ({
+                  checked: [!prev.checked[0], prev.checked[1]],
+                }))
+              }
+            />
+            <PledgeItem
+              title="타인의 웹메일, 카카오톡 ID, 전화번호를 도용/대여하지 않을게요. "
+              checked={pageState.checked[1]}
+              onClick={() =>
+                setPageState(prev => ({
+                  checked: [prev.checked[0], !prev.checked[1]],
+                }))
+              }
             />
           </Col>
         </Col>


### PR DESCRIPTION
# Summary

- 서약 체크박스 두개를 추가하였습니다.

![image](https://github.com/uoslife/client-meeting-season4/assets/97388599/000ba8f4-76c0-4848-ab3e-44ab905fcb17)
- validation을 적용하였습니다. 이제 체크를 해야 다음 페이지로 넘어갈 수 있습니다.
- PledgeItem을 재활용하는 과정에서, 몇몇 prop을 optional type 으로 수정하였습니다.