### PR TITLE
[M4FE-9] 2차 QA UI 수정

### DIFF
--- a/src/api/services/meeting.ts
+++ b/src/api/services/meeting.ts
@@ -52,8 +52,8 @@ const updateMessage = async <T = object>(
   teamType: TeamType,
   isTeamLeader: boolean,
   data: UpdateMessageRequest,
-): PromiseAxios<T> => {
-  return API.put(`/api/meeting/${teamType}/${isTeamLeader}/message`, data);
+) => {
+  return API.put<T>(`/api/meeting/${teamType}/${isTeamLeader}/message`, data);
 };
 
 // 팅의 모든 정보를 받아옵니다.

--- a/src/components/applyInfo/DirectoryViewInfoList.tsx
+++ b/src/components/applyInfo/DirectoryViewInfoList.tsx
@@ -32,7 +32,12 @@ const DirectoryViewInfoItem = ({ name, content }: ItemComponentProps) => {
       <Paddler left={16}>
         <Row gap={16}>
           <IconButton iconName="directory/directory-connector" format="png" />
-          <Text color="Gray500" typography="GoThicBodyS" label={content} />
+          <Text
+            align="left"
+            color="Gray500"
+            typography="GoThicBodyS"
+            label={content}
+          />
         </Row>
       </Paddler>
     </Col>

--- a/src/components/modal/applicationModal/ApplicationModal.style.tsx
+++ b/src/components/modal/applicationModal/ApplicationModal.style.tsx
@@ -1,28 +1,6 @@
 import styled from '@emotion/styled';
 import { colors } from '~/styles/colors';
-import { keyframes } from '@emotion/react';
-
-export const downToUp = keyframes`
-  0% {
-    opacity: 0;
-    transform: translateY(100%);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-`;
-
-export const upToDown = keyframes`
-  0% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  100% {
-    opacity: 0;
-    transform: translateY(100%);
-  }
-`;
+import { css } from '@emotion/react';
 
 export const Container = styled.div<{ isActive: boolean }>`
   position: fixed;
@@ -38,7 +16,11 @@ export const Container = styled.div<{ isActive: boolean }>`
   width: 100%;
   box-shadow: 0px -4px 36px rgba(0, 0, 0, 0.08);
   background-color: white;
-  animation: ${({ isActive }) => (isActive ? downToUp : upToDown)} 0.5s forwards;
+
+  opacity: ${({ isActive }) => (isActive ? 1 : 0)};
+  transform: ${({ isActive }) =>
+    isActive ? css`translateY(0)` : css`translateY(100%)`};
+  transition: all 0.3s ease-in-out;
 `;
 
 export const GrayHandler = styled.div`

--- a/src/models/common/data.ts
+++ b/src/models/common/data.ts
@@ -22,11 +22,17 @@ export const commonInitialData: CommonData = {
   },
   commonVerifyForCheckAfterAlreadyAppliedStep: {
     page1: {
+      univType: null,
+    },
+    page2: {
       verified: false,
     },
   },
   commonVerifyForMatchingResultStep: {
     page1: {
+      univType: null,
+    },
+    page2: {
       verified: false,
     },
   },
@@ -59,11 +65,19 @@ export const commonDataAtoms: CommonDataAtoms = {
       'commonVerifyForCheckAfterAlreadyAppliedStep-page1',
       commonInitialData.commonVerifyForCheckAfterAlreadyAppliedStep.page1,
     ),
+    page2: atomWithStorage(
+      'commonVerifyForCheckAfterAlreadyAppliedStep-page2',
+      commonInitialData.commonVerifyForCheckAfterAlreadyAppliedStep.page2,
+    ),
   },
   commonVerifyForMatchingResultStep: {
     page1: atomWithStorage(
       'commonVerifyForMatchingResultStep-page1',
       commonInitialData.commonVerifyForMatchingResultStep.page1,
+    ),
+    page2: atomWithStorage(
+      'commonVerifyForMatchingResultStep-page2',
+      commonInitialData.commonVerifyForMatchingResultStep.page2,
     ),
   },
 };

--- a/src/models/common/data.type.ts
+++ b/src/models/common/data.type.ts
@@ -21,11 +21,17 @@ export type CommonData = {
   };
   commonVerifyForCheckAfterAlreadyAppliedStep: {
     page1: {
+      univType: Univ | null;
+    };
+    page2: {
       verified: boolean;
     };
   };
   commonVerifyForMatchingResultStep: {
     page1: {
+      univType: Univ | null;
+    };
+    page2: {
       verified: boolean;
     };
   };

--- a/src/models/common/validation.ts
+++ b/src/models/common/validation.ts
@@ -15,10 +15,12 @@ export const commonValidators: CommonValidator = {
       !!meetingType && checked.every(Boolean),
   },
   commonVerifyForCheckAfterAlreadyAppliedStep: {
-    page1: ({ verified }) => verified,
+    page1: ({ univType }) => !!univType,
+    page2: ({ verified }) => verified,
   },
   commonVerifyForMatchingResultStep: {
-    page1: ({ verified }) => verified,
+    page1: ({ univType }) => !!univType,
+    page2: ({ verified }) => verified,
   },
 };
 
@@ -44,10 +46,16 @@ export const commonValiditiesAtom = atom<CommonValidites>(get => ({
     page1: commonValidators.commonVerifyForCheckAfterAlreadyAppliedStep.page1(
       get(commonDataAtoms.commonVerifyForCheckAfterAlreadyAppliedStep.page1),
     ),
+    page2: commonValidators.commonVerifyForCheckAfterAlreadyAppliedStep.page2(
+      get(commonDataAtoms.commonVerifyForCheckAfterAlreadyAppliedStep.page2),
+    ),
   },
   commonVerifyForMatchingResultStep: {
     page1: commonValidators.commonVerifyForMatchingResultStep.page1(
       get(commonDataAtoms.commonVerifyForMatchingResultStep.page1),
+    ),
+    page2: commonValidators.commonVerifyForMatchingResultStep.page2(
+      get(commonDataAtoms.commonVerifyForMatchingResultStep.page2),
     ),
   },
 }));

--- a/src/pages/common/checkApplyInfoStep/Step.tsx
+++ b/src/pages/common/checkApplyInfoStep/Step.tsx
@@ -34,26 +34,28 @@ const CommonCheckApplyInfoStep = () => {
   const openModal = () => setIsModalOpen(true);
 
   return (
-    <PageLayout>
-      <PageLayout.Header title={headerTitle} isProgress={false} />
-      <FirstPage />
-      <PageLayout.Footer
-        innerPadding="20px 20px"
-        outerPadding="22px 16px"
-        backgroundColorName="White"
-        borderExceptTop={`1px solid ${colors.Gray200}`}
-        borderBottomRadius={21}
-        totalPage={1}
-        currentPage={currentPage}
-        onPrev={PageHandler.onPrev}
-        onNext={openModal}
-      />
+    <>
+      <PageLayout>
+        <PageLayout.Header title={headerTitle} isProgress={false} />
+        <FirstPage />
+        <PageLayout.Footer
+          innerPadding="20px 20px"
+          outerPadding="22px 16px"
+          backgroundColorName="White"
+          borderExceptTop={`1px solid ${colors.Gray200}`}
+          borderBottomRadius={21}
+          totalPage={1}
+          currentPage={currentPage}
+          onPrev={PageHandler.onPrev}
+          onNext={openModal}
+        />
+      </PageLayout>
       <ApplicationModal
         isActive={isModalOpen}
         cancelButtonClicked={closeModal}
         joinButtonClicked={PageHandler.onNext}
       />
-    </PageLayout>
+    </>
   );
 };
 

--- a/src/pages/common/verifyForCheckAfterAleadyAppliedStep/FirstPage.tsx
+++ b/src/pages/common/verifyForCheckAfterAleadyAppliedStep/FirstPage.tsx
@@ -1,210 +1,56 @@
-import { css } from '@emotion/react';
-import { useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useState } from 'react';
-import { AuthAPI } from '~/api';
-import RoundButton from '~/components/buttons/roundButton/RoundButton';
-import TextInput from '~/components/inputs/textInput/TextInput';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import IconButton from '~/components/buttons/iconButton/IconButton';
 import Col from '~/components/layout/Col';
 import Paddler from '~/components/layout/Pad';
 import Row from '~/components/layout/Row';
-
 import Text from '~/components/typography/Text';
-import { useInput } from '~/hooks/useInput';
 import { combinedValidatiesAtoms } from '~/models';
 import { commonDataAtoms } from '~/models/common/data';
 import { pageFinishAtom } from '~/models/funnel';
+import { UnivSelectContainer } from '../univVerificationStep/FirstPage';
 
-// copied from src\pages\common\univVerificationStep\ThirdPage.tsx
+const UNIV_SELECTION_LIST = ['KHU', 'HUFS'] as const;
+
 const FirstPage = () => {
+  const [pageState, setPageState] = useAtom(
+    commonDataAtoms.commonVerifyForCheckAfterAlreadyAppliedStep.page1,
+  );
+  const { univType } = pageState;
   const setIsPageFinished = useSetAtom(pageFinishAtom);
   const pageValidity = useAtomValue(combinedValidatiesAtoms)
     .commonVerifyForCheckAfterAlreadyAppliedStep.page1;
-  const tempUnivType = 'KHU'; // 기획 결정 후 수정
   setIsPageFinished(pageValidity);
-
-  const setPageState = useSetAtom(
-    commonDataAtoms.commonVerifyForCheckAfterAlreadyAppliedStep.page1,
-  );
-
-  const { inputValue, handleInputChange } = useInput('');
-  const {
-    inputValue: validateCodeValue,
-    setValueClear: resetValidateCode,
-    handleInputChange: handleValidateCodeValue,
-  } = useInput('');
-  const [timer, setTimer] = useState(60 * 60);
-  const [tryValidate, setTryValidate] = useState(false);
-  const [validateStatus, setValidateStatus] = useState('');
-  const [statusMessage, setStatusMessage] = useState(
-    '메일로 발송된 인증번호를 입력해주세요.',
-  );
-
-  const handleValidateCodeInput = (value: string) => {
-    switch (value) {
-      case '':
-        return 'default';
-      case 'error':
-        return `error`;
-      case 'success':
-        return `focused`;
-      default:
-        return 'default';
-    }
-  };
-
-  const handleValidateCodeMessage = (value: string) => {
-    switch (value) {
-      case '':
-        return 'Gray500';
-      case 'error':
-        return `Red200`;
-      case 'success':
-        return `Primary500`;
-      default:
-        return 'Gray500';
-    }
-  };
-  // 인증번호 확인 절차
-  const handleTryValidate = async () => {
-    if (inputValue) setTryValidate(true);
-    const res = await AuthAPI.getVerificationCode({
-      email: inputValue,
-      university: tempUnivType,
-    });
-
-    console.log(res);
-  };
-
-  // 인증번호 확인 절차
-  const handleValidate = async () => {
-    if (!validateCodeValue) return setStatusMessage('인증번호를 입력해주세요!');
-    if (validateCodeValue === '1234') {
-      const res = await AuthAPI.checkVerificationCode({
-        code: parseInt(validateCodeValue),
-        email: inputValue,
-        university: tempUnivType,
-      });
-      const result = res.data;
-      console.log(result);
-      setPageState({ verified: true });
-      localStorage.setItem('accessToken', result.accessToken);
-      localStorage.setItem('refreshToken', result.refreshToken);
-      setStatusMessage('인증되었습니다.');
-      setValidateStatus('success');
-    } else {
-      setStatusMessage('유효하지 않은 인증번호입니다.');
-      setValidateStatus('error');
-      resetValidateCode();
-    }
-  };
-  useEffect(() => {
-    let interval: number;
-    if (tryValidate) {
-      if (timer === 0) {
-        setStatusMessage(
-          '제한 시간이 만료되었습니다. 인증 코드를 재발급해주세요!',
-        );
-        setValidateStatus('error');
-        return;
-      }
-      interval = setInterval(() => {
-        setTimer(prevTime => prevTime - 1);
-      }, 1000);
-    }
-    return () => clearInterval(interval);
-  }, [timer, tryValidate]);
-
-  const minutes = Math.floor(timer / 60);
-  const seconds = timer % 60;
 
   return (
     <Paddler top={36} right={20} bottom={24} left={20}>
-      <Col gap={28}>
-        <Col align={'center'} gap={12}>
-          <Text
-            label={'학교 웹메일을 입력해 주세요 (*^࿄^*)'}
-            color={'Gray500'}
-            typography={'NeoTitleM'}
-          />
-          <Text
-            label={
-              '‘시대팅X트로이카’는 시립대, 경희대, 한국외대\n' +
-              ' 학생들에게만 제공되는 서비스입니다.\n' +
-              '해당 학교 구성원임을 인증 후 신청을 진행해 주세요!'
-            }
-            color={'Gray400'}
-            typography={'GoThicBodyS'}
-            css={css`
-              text-align: center;
-            `}
-          />
-        </Col>
-        <Col gap={12}>
-          <Row gap={8}>
-            <TextInput
-              placeholder={'웹메일 주소 입력'}
-              value={inputValue}
-              status={'default'}
-              isAuthentication={true}
-              onChange={handleInputChange}>
-              <Text
-                label={tempUnivType === 'KHU' ? '@khu.ac.kr' : '@hufs.ac.kr'}
-                color={'Gray400'}
-                typography={'GoThicButtonM'}
-                css={css`
-                  padding-left: 5px;
-                `}
-              />
-            </TextInput>
-            <RoundButton
-              onClick={handleTryValidate}
-              status={inputValue ? 'active' : 'disabled'}
-              borderType={'gray'}
-              height={44}
-              width={94}>
-              <Text
-                label={tryValidate ? '재전송' : '인증하기'}
-                color={'White'}
-                typography={'NeoButtonS'}
-              />
-            </RoundButton>
-          </Row>
-          {tryValidate && (
-            <Col gap={6}>
-              <Row gap={8}>
-                {/*TODO: 인증번호가 숫자인지 문자인지 백엔드쪽에 확인해서 input type 제한 걸기*/}
-                <TextInput
-                  placeholder={'인증번호 입력(1234)'}
-                  value={validateCodeValue}
-                  status={handleValidateCodeInput(validateStatus)}
-                  onChange={handleValidateCodeValue}>
-                  <Text
-                    label={`${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`}
-                    color={'Gray300'}
-                    typography={'GoThicButtonM'}
-                  />
-                </TextInput>
-                <RoundButton
-                  onClick={handleValidate}
-                  status={validateCodeValue ? 'active' : 'disabled'}
-                  borderType={'gray'}
-                  height={44}
-                  width={94}>
-                  <Text
-                    label={'확인'}
-                    color={'White'}
-                    typography={'NeoButtonS'}
-                  />
-                </RoundButton>
-              </Row>
-              <Text
-                label={statusMessage}
-                color={handleValidateCodeMessage(validateStatus)}
-                typography={'GoThicLabelS'}
-              />
-            </Col>
-          )}
-        </Col>
+      <Col align={'center'} gap={52}>
+        <Text
+          label={'본인 학교를 선택해 주세요 (˵^࿄^˵)'}
+          color={'Gray500'}
+          typography={'NeoTitleM'}
+        />
+        <Row gap={20} justify={'center'}>
+          {UNIV_SELECTION_LIST.map((univ, index) => {
+            return (
+              <UnivSelectContainer
+                key={`${univ} - ${index}`}
+                isClicked={univType === univ}
+                onClick={() => setPageState({ univType: univ })}>
+                <IconButton
+                  iconName={`univSelection/${univ}`}
+                  format={'png'}
+                  width={univ === 'KHU' ? 96 : 170}
+                  height={130}
+                />
+                <Text
+                  label={univ === 'KHU' ? '경희대학교' : '한국외국어대학교'}
+                  color={'Gray300'}
+                  typography={'NeoBodyM'}
+                />
+              </UnivSelectContainer>
+            );
+          })}
+        </Row>
       </Col>
     </Paddler>
   );

--- a/src/pages/common/verifyForCheckAfterAleadyAppliedStep/SecondPage.tsx
+++ b/src/pages/common/verifyForCheckAfterAleadyAppliedStep/SecondPage.tsx
@@ -1,0 +1,215 @@
+import { css } from '@emotion/react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useEffect, useState } from 'react';
+import { AuthAPI } from '~/api';
+import RoundButton from '~/components/buttons/roundButton/RoundButton';
+import TextInput from '~/components/inputs/textInput/TextInput';
+import Col from '~/components/layout/Col';
+import Paddler from '~/components/layout/Pad';
+import Row from '~/components/layout/Row';
+
+import Text from '~/components/typography/Text';
+import { useInput } from '~/hooks/useInput';
+import { combinedValidatiesAtoms } from '~/models';
+import { commonDataAtoms } from '~/models/common/data';
+import { pageFinishAtom } from '~/models/funnel';
+
+// copied from src\pages\common\univVerificationStep\ThirdPage.tsx
+const SecondPage = () => {
+  const setIsPageFinished = useSetAtom(pageFinishAtom);
+  const pageValidity = useAtomValue(combinedValidatiesAtoms)
+    .commonVerifyForCheckAfterAlreadyAppliedStep.page2;
+  const { univType } = useAtomValue(
+    commonDataAtoms.commonVerifyForCheckAfterAlreadyAppliedStep.page1,
+  );
+  setIsPageFinished(pageValidity);
+
+  const setPageState = useSetAtom(
+    commonDataAtoms.commonVerifyForCheckAfterAlreadyAppliedStep.page2,
+  );
+
+  const { inputValue, handleInputChange } = useInput('');
+  const {
+    inputValue: validateCodeValue,
+    setValueClear: resetValidateCode,
+    handleInputChange: handleValidateCodeValue,
+  } = useInput('');
+  const [timer, setTimer] = useState(60 * 60);
+  const [tryValidate, setTryValidate] = useState(false);
+  const [validateStatus, setValidateStatus] = useState('');
+  const [statusMessage, setStatusMessage] = useState(
+    '메일로 발송된 인증번호를 입력해주세요.',
+  );
+
+  const handleValidateCodeInput = (value: string) => {
+    switch (value) {
+      case '':
+        return 'default';
+      case 'error':
+        return `error`;
+      case 'success':
+        return `focused`;
+      default:
+        return 'default';
+    }
+  };
+
+  const handleValidateCodeMessage = (value: string) => {
+    switch (value) {
+      case '':
+        return 'Gray500';
+      case 'error':
+        return `Red200`;
+      case 'success':
+        return `Primary500`;
+      default:
+        return 'Gray500';
+    }
+  };
+  // 인증번호 확인 절차
+  const handleTryValidate = async () => {
+    if (inputValue) setTryValidate(true);
+    const res = await AuthAPI.getVerificationCode({
+      email: inputValue,
+      university: univType,
+    });
+
+    console.log(res);
+  };
+
+  // 인증번호 확인 절차
+  const handleValidate = async () => {
+    if (!validateCodeValue) return setStatusMessage('인증번호를 입력해주세요!');
+    if (validateCodeValue === '1234') {
+      const res = await AuthAPI.checkVerificationCode({
+        code: parseInt(validateCodeValue),
+        email: inputValue,
+        university: univType,
+      });
+      const result = res.data;
+      console.log(result);
+      setPageState({ verified: true });
+      localStorage.setItem('accessToken', result.accessToken);
+      localStorage.setItem('refreshToken', result.refreshToken);
+      setStatusMessage('인증되었습니다.');
+      setValidateStatus('success');
+    } else {
+      setStatusMessage('유효하지 않은 인증번호입니다.');
+      setValidateStatus('error');
+      resetValidateCode();
+    }
+  };
+  useEffect(() => {
+    let interval: number;
+    if (tryValidate) {
+      if (timer === 0) {
+        setStatusMessage(
+          '제한 시간이 만료되었습니다. 인증 코드를 재발급해주세요!',
+        );
+        setValidateStatus('error');
+        return;
+      }
+      interval = setInterval(() => {
+        setTimer(prevTime => prevTime - 1);
+      }, 1000);
+    }
+    return () => clearInterval(interval);
+  }, [timer, tryValidate]);
+
+  const minutes = Math.floor(timer / 60);
+  const seconds = timer % 60;
+
+  return (
+    <Paddler top={36} right={20} bottom={24} left={20}>
+      <Col gap={28}>
+        <Col align={'center'} gap={12}>
+          <Text
+            label={'학교 웹메일을 입력해 주세요 (*^࿄^*)'}
+            color={'Gray500'}
+            typography={'NeoTitleM'}
+          />
+          <Text
+            label={
+              '‘시대팅X트로이카’는 시립대, 경희대, 한국외대\n' +
+              ' 학생들에게만 제공되는 서비스입니다.\n' +
+              '해당 학교 구성원임을 인증 후 신청을 진행해 주세요!'
+            }
+            color={'Gray400'}
+            typography={'GoThicBodyS'}
+            css={css`
+              text-align: center;
+            `}
+          />
+        </Col>
+        <Col gap={12}>
+          <Row gap={8}>
+            <TextInput
+              placeholder={'웹메일 주소 입력'}
+              value={inputValue}
+              status={'default'}
+              isAuthentication={true}
+              onChange={handleInputChange}>
+              <Text
+                label={univType === 'KHU' ? '@khu.ac.kr' : '@hufs.ac.kr'}
+                color={'Gray400'}
+                typography={'GoThicButtonM'}
+                css={css`
+                  padding-left: 5px;
+                `}
+              />
+            </TextInput>
+            <RoundButton
+              onClick={handleTryValidate}
+              status={inputValue ? 'active' : 'disabled'}
+              borderType={'gray'}
+              height={44}
+              width={94}>
+              <Text
+                label={tryValidate ? '재전송' : '인증하기'}
+                color={'White'}
+                typography={'NeoButtonS'}
+              />
+            </RoundButton>
+          </Row>
+          {tryValidate && (
+            <Col gap={6}>
+              <Row gap={8}>
+                {/*TODO: 인증번호가 숫자인지 문자인지 백엔드쪽에 확인해서 input type 제한 걸기*/}
+                <TextInput
+                  placeholder={'인증번호 입력(1234)'}
+                  value={validateCodeValue}
+                  status={handleValidateCodeInput(validateStatus)}
+                  onChange={handleValidateCodeValue}>
+                  <Text
+                    label={`${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`}
+                    color={'Gray300'}
+                    typography={'GoThicButtonM'}
+                  />
+                </TextInput>
+                <RoundButton
+                  onClick={handleValidate}
+                  status={validateCodeValue ? 'active' : 'disabled'}
+                  borderType={'gray'}
+                  height={44}
+                  width={94}>
+                  <Text
+                    label={'확인'}
+                    color={'White'}
+                    typography={'NeoButtonS'}
+                  />
+                </RoundButton>
+              </Row>
+              <Text
+                label={statusMessage}
+                color={handleValidateCodeMessage(validateStatus)}
+                typography={'GoThicLabelS'}
+              />
+            </Col>
+          )}
+        </Col>
+      </Col>
+    </Paddler>
+  );
+};
+
+export default SecondPage;

--- a/src/pages/common/verifyForCheckAfterAleadyAppliedStep/Step.tsx
+++ b/src/pages/common/verifyForCheckAfterAleadyAppliedStep/Step.tsx
@@ -1,10 +1,11 @@
 import PageLayout from '~/components/layout/page/PageLayout';
-import FirstPage from './FirstPage';
 import { useFunnel } from '~/hooks/useFunnel';
+import FirstPage from './FirstPage';
+import SecondPage from './SecondPage';
 
 const CommonVerifyForCheckAfterAlreadyAppliedStep = () => {
-  const { PageHandler } = useFunnel({
-    pageNumberList: [1],
+  const { PageHandler, Funnel, currentPage } = useFunnel({
+    pageNumberList: [1, 2],
     prevStep: { path: '/' },
     nextStep: { path: '/common/checkAfterAlreadyAppliedStep' },
   });
@@ -13,11 +14,18 @@ const CommonVerifyForCheckAfterAlreadyAppliedStep = () => {
     <PageLayout>
       <PageLayout.Header title="신청 정보 확인하기" />
       <PageLayout.SingleCardBody>
-        <FirstPage />
+        <Funnel>
+          <Funnel.Page pageNumber={1}>
+            <FirstPage />
+          </Funnel.Page>
+          <Funnel.Page pageNumber={2}>
+            <SecondPage />
+          </Funnel.Page>
+        </Funnel>
       </PageLayout.SingleCardBody>
       <PageLayout.Footer
-        currentPage={1}
-        totalPage={1}
+        currentPage={currentPage}
+        totalPage={2}
         onPrev={PageHandler.onPrev}
         onNext={PageHandler.onNext}
       />

--- a/src/pages/common/verifyForMatchingResultStep/FirstPage.tsx
+++ b/src/pages/common/verifyForMatchingResultStep/FirstPage.tsx
@@ -1,208 +1,56 @@
-import { css } from '@emotion/react';
-import { useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useState } from 'react';
-import { AuthAPI } from '~/api';
-import RoundButton from '~/components/buttons/roundButton/RoundButton';
-import TextInput from '~/components/inputs/textInput/TextInput';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import IconButton from '~/components/buttons/iconButton/IconButton';
 import Col from '~/components/layout/Col';
 import Paddler from '~/components/layout/Pad';
 import Row from '~/components/layout/Row';
 import Text from '~/components/typography/Text';
-import { useInput } from '~/hooks/useInput';
 import { combinedValidatiesAtoms } from '~/models';
 import { commonDataAtoms } from '~/models/common/data';
 import { pageFinishAtom } from '~/models/funnel';
+import { UnivSelectContainer } from '../univVerificationStep/FirstPage';
 
-// copied from src\pages\common\univVerificationStep\ThirdPage.tsx
+const UNIV_SELECTION_LIST = ['KHU', 'HUFS'] as const;
+
 const FirstPage = () => {
+  const [pageState, setPageState] = useAtom(
+    commonDataAtoms.commonVerifyForMatchingResultStep.page1,
+  );
+  const { univType } = pageState;
   const setIsPageFinished = useSetAtom(pageFinishAtom);
   const pageValidity = useAtomValue(combinedValidatiesAtoms)
     .commonVerifyForMatchingResultStep.page1;
-  const tempUnivType = 'KHU'; // 기획 결정 후 수정
   setIsPageFinished(pageValidity);
-
-  const setPageState = useSetAtom(
-    commonDataAtoms.commonVerifyForMatchingResultStep.page1,
-  );
-
-  const { inputValue, handleInputChange } = useInput('');
-  const {
-    inputValue: validateCodeValue,
-    setValueClear: resetValidateCode,
-    handleInputChange: handleValidateCodeValue,
-  } = useInput('');
-  const [timer, setTimer] = useState(60 * 60);
-  const [tryValidate, setTryValidate] = useState(false);
-  const [validateStatus, setValidateStatus] = useState('');
-  const [statusMessage, setStatusMessage] = useState(
-    '메일로 발송된 인증번호를 입력해주세요.',
-  );
-
-  const handleValidateCodeInput = (value: string) => {
-    switch (value) {
-      case '':
-        return 'default';
-      case 'error':
-        return `error`;
-      case 'success':
-        return `focused`;
-      default:
-        return 'default';
-    }
-  };
-
-  const handleValidateCodeMessage = (value: string) => {
-    switch (value) {
-      case '':
-        return 'Gray500';
-      case 'error':
-        return `Red200`;
-      case 'success':
-        return `Primary500`;
-      default:
-        return 'Gray500';
-    }
-  };
-  // 인증번호 확인 절차
-  const handleTryValidate = async () => {
-    if (inputValue) setTryValidate(true);
-    const res = await AuthAPI.getVerificationCode({
-      email: inputValue,
-      university: tempUnivType,
-    });
-
-    console.log(res);
-  };
-
-  // 인증번호 확인 절차
-  const handleValidate = async () => {
-    if (!validateCodeValue) return setStatusMessage('인증번호를 입력해주세요!');
-    if (validateCodeValue === '1234') {
-      const res = await AuthAPI.checkVerificationCode({
-        code: parseInt(validateCodeValue),
-        email: inputValue,
-        university: tempUnivType,
-      });
-      const result = res.data;
-      console.log(result);
-      setPageState({ verified: true });
-      localStorage.setItem('accessToken', result.accessToken);
-      localStorage.setItem('refreshToken', result.refreshToken);
-      setStatusMessage('인증되었습니다.');
-      setValidateStatus('success');
-    } else {
-      setStatusMessage('유효하지 않은 인증번호입니다.');
-      setValidateStatus('error');
-      resetValidateCode();
-    }
-  };
-  useEffect(() => {
-    let interval: number;
-    if (tryValidate) {
-      if (timer === 0) {
-        setStatusMessage(
-          '제한 시간이 만료되었습니다. 인증 코드를 재발급해주세요!',
-        );
-        setValidateStatus('error');
-        return;
-      }
-      interval = setInterval(() => {
-        setTimer(prevTime => prevTime - 1);
-      }, 1000);
-    }
-    return () => clearInterval(interval);
-  }, [timer, tryValidate]);
-
-  const minutes = Math.floor(timer / 60);
-  const seconds = timer % 60;
 
   return (
     <Paddler top={36} right={20} bottom={24} left={20}>
-      <Col gap={28}>
-        <Col align={'center'} gap={12}>
-          <Text
-            label={'학교 웹메일을 입력해 주세요(˵¯͒࿄¯͒˵)'}
-            color={'Gray500'}
-            typography={'NeoTitleM'}
-          />
-          <Text
-            label={
-              '본인의 학교 웹메일을 통해\n' +
-              '나만의 매칭 결과를 확인해보세요.\n'
-            }
-            color={'Gray400'}
-            typography={'GoThicBodyS'}
-            css={css`
-              text-align: center;
-            `}
-          />
-        </Col>
-        <Col gap={12}>
-          <Row gap={8}>
-            <TextInput
-              placeholder={'웹메일 주소 입력'}
-              value={inputValue}
-              status={'default'}
-              isAuthentication={true}
-              onChange={handleInputChange}>
-              <Text
-                label={tempUnivType === 'KHU' ? '@khu.ac.kr' : '@hufs.ac.kr'}
-                color={'Gray400'}
-                typography={'GoThicButtonM'}
-                css={css`
-                  padding-left: 5px;
-                `}
-              />
-            </TextInput>
-            <RoundButton
-              onClick={handleTryValidate}
-              status={inputValue ? 'active' : 'disabled'}
-              borderType={'gray'}
-              height={44}
-              width={94}>
-              <Text
-                label={tryValidate ? '재전송' : '인증하기'}
-                color={'White'}
-                typography={'NeoButtonS'}
-              />
-            </RoundButton>
-          </Row>
-          {tryValidate && (
-            <Col gap={6}>
-              <Row gap={8}>
-                {/*TODO: 인증번호가 숫자인지 문자인지 백엔드쪽에 확인해서 input type 제한 걸기*/}
-                <TextInput
-                  placeholder={'인증번호 입력(1234)'}
-                  value={validateCodeValue}
-                  status={handleValidateCodeInput(validateStatus)}
-                  onChange={handleValidateCodeValue}>
-                  <Text
-                    label={`${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`}
-                    color={'Gray300'}
-                    typography={'GoThicButtonM'}
-                  />
-                </TextInput>
-                <RoundButton
-                  onClick={handleValidate}
-                  status={validateCodeValue ? 'active' : 'disabled'}
-                  borderType={'gray'}
-                  height={44}
-                  width={94}>
-                  <Text
-                    label={'확인'}
-                    color={'White'}
-                    typography={'NeoButtonS'}
-                  />
-                </RoundButton>
-              </Row>
-              <Text
-                label={statusMessage}
-                color={handleValidateCodeMessage(validateStatus)}
-                typography={'GoThicLabelS'}
-              />
-            </Col>
-          )}
-        </Col>
+      <Col align={'center'} gap={52}>
+        <Text
+          label={'본인 학교를 선택해 주세요 (˵^࿄^˵)'}
+          color={'Gray500'}
+          typography={'NeoTitleM'}
+        />
+        <Row gap={20} justify={'center'}>
+          {UNIV_SELECTION_LIST.map((univ, index) => {
+            return (
+              <UnivSelectContainer
+                key={`${univ} - ${index}`}
+                isClicked={univType === univ}
+                onClick={() => setPageState({ univType: univ })}>
+                <IconButton
+                  iconName={`univSelection/${univ}`}
+                  format={'png'}
+                  width={univ === 'KHU' ? 96 : 170}
+                  height={130}
+                />
+                <Text
+                  label={univ === 'KHU' ? '경희대학교' : '한국외국어대학교'}
+                  color={'Gray300'}
+                  typography={'NeoBodyM'}
+                />
+              </UnivSelectContainer>
+            );
+          })}
+        </Row>
       </Col>
     </Paddler>
   );

--- a/src/pages/common/verifyForMatchingResultStep/SecondPage.tsx
+++ b/src/pages/common/verifyForMatchingResultStep/SecondPage.tsx
@@ -1,0 +1,215 @@
+import { css } from '@emotion/react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useEffect, useState } from 'react';
+import { AuthAPI } from '~/api';
+import RoundButton from '~/components/buttons/roundButton/RoundButton';
+import TextInput from '~/components/inputs/textInput/TextInput';
+import Col from '~/components/layout/Col';
+import Paddler from '~/components/layout/Pad';
+import Row from '~/components/layout/Row';
+
+import Text from '~/components/typography/Text';
+import { useInput } from '~/hooks/useInput';
+import { combinedValidatiesAtoms } from '~/models';
+import { commonDataAtoms } from '~/models/common/data';
+import { pageFinishAtom } from '~/models/funnel';
+
+// copied from src\pages\common\univVerificationStep\ThirdPage.tsx
+const SecondPage = () => {
+  const setIsPageFinished = useSetAtom(pageFinishAtom);
+  const pageValidity = useAtomValue(combinedValidatiesAtoms)
+    .commonVerifyForMatchingResultStep.page2;
+  const { univType } = useAtomValue(
+    commonDataAtoms.commonVerifyForMatchingResultStep.page1,
+  );
+  setIsPageFinished(pageValidity);
+
+  const setPageState = useSetAtom(
+    commonDataAtoms.commonVerifyForMatchingResultStep.page2,
+  );
+
+  const { inputValue, handleInputChange } = useInput('');
+  const {
+    inputValue: validateCodeValue,
+    setValueClear: resetValidateCode,
+    handleInputChange: handleValidateCodeValue,
+  } = useInput('');
+  const [timer, setTimer] = useState(60 * 60);
+  const [tryValidate, setTryValidate] = useState(false);
+  const [validateStatus, setValidateStatus] = useState('');
+  const [statusMessage, setStatusMessage] = useState(
+    '메일로 발송된 인증번호를 입력해주세요.',
+  );
+
+  const handleValidateCodeInput = (value: string) => {
+    switch (value) {
+      case '':
+        return 'default';
+      case 'error':
+        return `error`;
+      case 'success':
+        return `focused`;
+      default:
+        return 'default';
+    }
+  };
+
+  const handleValidateCodeMessage = (value: string) => {
+    switch (value) {
+      case '':
+        return 'Gray500';
+      case 'error':
+        return `Red200`;
+      case 'success':
+        return `Primary500`;
+      default:
+        return 'Gray500';
+    }
+  };
+  // 인증번호 확인 절차
+  const handleTryValidate = async () => {
+    if (inputValue) setTryValidate(true);
+    const res = await AuthAPI.getVerificationCode({
+      email: inputValue,
+      university: univType,
+    });
+
+    console.log(res);
+  };
+
+  // 인증번호 확인 절차
+  const handleValidate = async () => {
+    if (!validateCodeValue) return setStatusMessage('인증번호를 입력해주세요!');
+    if (validateCodeValue === '1234') {
+      const res = await AuthAPI.checkVerificationCode({
+        code: parseInt(validateCodeValue),
+        email: inputValue,
+        university: univType,
+      });
+      const result = res.data;
+      console.log(result);
+      setPageState({ verified: true });
+      localStorage.setItem('accessToken', result.accessToken);
+      localStorage.setItem('refreshToken', result.refreshToken);
+      setStatusMessage('인증되었습니다.');
+      setValidateStatus('success');
+    } else {
+      setStatusMessage('유효하지 않은 인증번호입니다.');
+      setValidateStatus('error');
+      resetValidateCode();
+    }
+  };
+  useEffect(() => {
+    let interval: number;
+    if (tryValidate) {
+      if (timer === 0) {
+        setStatusMessage(
+          '제한 시간이 만료되었습니다. 인증 코드를 재발급해주세요!',
+        );
+        setValidateStatus('error');
+        return;
+      }
+      interval = setInterval(() => {
+        setTimer(prevTime => prevTime - 1);
+      }, 1000);
+    }
+    return () => clearInterval(interval);
+  }, [timer, tryValidate]);
+
+  const minutes = Math.floor(timer / 60);
+  const seconds = timer % 60;
+
+  return (
+    <Paddler top={36} right={20} bottom={24} left={20}>
+      <Col gap={28}>
+        <Col align={'center'} gap={12}>
+          <Text
+            label={'학교 웹메일을 입력해 주세요 (*^࿄^*)'}
+            color={'Gray500'}
+            typography={'NeoTitleM'}
+          />
+          <Text
+            label={
+              '‘시대팅X트로이카’는 시립대, 경희대, 한국외대\n' +
+              ' 학생들에게만 제공되는 서비스입니다.\n' +
+              '해당 학교 구성원임을 인증 후 신청을 진행해 주세요!'
+            }
+            color={'Gray400'}
+            typography={'GoThicBodyS'}
+            css={css`
+              text-align: center;
+            `}
+          />
+        </Col>
+        <Col gap={12}>
+          <Row gap={8}>
+            <TextInput
+              placeholder={'웹메일 주소 입력'}
+              value={inputValue}
+              status={'default'}
+              isAuthentication={true}
+              onChange={handleInputChange}>
+              <Text
+                label={univType === 'KHU' ? '@khu.ac.kr' : '@hufs.ac.kr'}
+                color={'Gray400'}
+                typography={'GoThicButtonM'}
+                css={css`
+                  padding-left: 5px;
+                `}
+              />
+            </TextInput>
+            <RoundButton
+              onClick={handleTryValidate}
+              status={inputValue ? 'active' : 'disabled'}
+              borderType={'gray'}
+              height={44}
+              width={94}>
+              <Text
+                label={tryValidate ? '재전송' : '인증하기'}
+                color={'White'}
+                typography={'NeoButtonS'}
+              />
+            </RoundButton>
+          </Row>
+          {tryValidate && (
+            <Col gap={6}>
+              <Row gap={8}>
+                {/*TODO: 인증번호가 숫자인지 문자인지 백엔드쪽에 확인해서 input type 제한 걸기*/}
+                <TextInput
+                  placeholder={'인증번호 입력(1234)'}
+                  value={validateCodeValue}
+                  status={handleValidateCodeInput(validateStatus)}
+                  onChange={handleValidateCodeValue}>
+                  <Text
+                    label={`${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`}
+                    color={'Gray300'}
+                    typography={'GoThicButtonM'}
+                  />
+                </TextInput>
+                <RoundButton
+                  onClick={handleValidate}
+                  status={validateCodeValue ? 'active' : 'disabled'}
+                  borderType={'gray'}
+                  height={44}
+                  width={94}>
+                  <Text
+                    label={'확인'}
+                    color={'White'}
+                    typography={'NeoButtonS'}
+                  />
+                </RoundButton>
+              </Row>
+              <Text
+                label={statusMessage}
+                color={handleValidateCodeMessage(validateStatus)}
+                typography={'GoThicLabelS'}
+              />
+            </Col>
+          )}
+        </Col>
+      </Col>
+    </Paddler>
+  );
+};
+
+export default SecondPage;

--- a/src/pages/common/verifyForMatchingResultStep/Step.tsx
+++ b/src/pages/common/verifyForMatchingResultStep/Step.tsx
@@ -1,11 +1,12 @@
 import PageLayout from '~/components/layout/page/PageLayout';
 import { useFunnel } from '~/hooks/useFunnel';
 import FirstPage from './FirstPage';
+import SecondPage from './SecondPage';
 
-const PAGE_NUMBER = [1];
+const PAGE_NUMBER = [1, 2];
 
 const CommonVerifyForMatchingResultStep = () => {
-  const { Funnel, PageHandler } = useFunnel({
+  const { Funnel, PageHandler, currentPage } = useFunnel({
     pageNumberList: PAGE_NUMBER,
     prevStep: { path: '/' },
     nextStep: { path: '/' }, // TODO: 시대팅 안내 사항 보러가기 페이지로 수정
@@ -19,11 +20,14 @@ const CommonVerifyForMatchingResultStep = () => {
           <Funnel.Page pageNumber={1}>
             <FirstPage />
           </Funnel.Page>
+          <Funnel.Page pageNumber={2}>
+            <SecondPage />
+          </Funnel.Page>
         </Funnel>
       </PageLayout.SingleCardBody>
       <PageLayout.Footer
-        currentPage={1}
-        totalPage={1}
+        currentPage={currentPage}
+        totalPage={2}
         onPrev={PageHandler.onPrev}
         onNext={PageHandler.onNext}
       />

--- a/src/pages/personal/myInformationStep/FifthPage.tsx
+++ b/src/pages/personal/myInformationStep/FifthPage.tsx
@@ -57,7 +57,7 @@ const Fifthpage = () => {
             <Col gap={32}>
               <Col align="center">
                 <Text
-                  label={'12. 본인의 MBTI를 선택해 주세요.'}
+                  label={'13. 본인의 MBTI를 선택해 주세요.'}
                   color={'Gray500'}
                   typography={'NeoButtonL'}
                   weight={400}

--- a/src/pages/personal/myInformationStep/ForthPage.tsx
+++ b/src/pages/personal/myInformationStep/ForthPage.tsx
@@ -31,7 +31,7 @@ const ForthPage = () => {
             <Col gap={32}>
               <Col gap={12} align="center">
                 <Text
-                  label={'11. 본인과 닮은 동물상을 선택해 주세요.'}
+                  label={'12. 본인과 닮은 동물상을 선택해 주세요.'}
                   color={'Gray500'}
                   typography={'NeoTitleM'}
                   weight={400}

--- a/src/pages/personal/myInformationStep/SixthPage.tsx
+++ b/src/pages/personal/myInformationStep/SixthPage.tsx
@@ -30,7 +30,7 @@ const SixthPage = () => {
           <Row>
             <Col gap={32} align="center">
               <Text
-                label={'12. 본인의 관심사를 3가지 선택해 주세요.'}
+                label={'14. 본인의 관심사를 3가지 선택해 주세요.'}
                 color={'Gray500'}
                 typography={'NeoTitleM'}
                 weight={400}

--- a/src/pages/personal/myInformationStep/ThirdPage.tsx
+++ b/src/pages/personal/myInformationStep/ThirdPage.tsx
@@ -31,7 +31,7 @@ const ThirdPage = () => {
             <Col gap={56}>
               <Col gap={28} align="center">
                 <Text
-                  label={'8. 본인의 종교를 선택해 주세요.'}
+                  label={'9. 본인의 종교를 선택해 주세요.'}
                   color={'Gray500'}
                   typography={'NeoTitleM'}
                   weight={400}
@@ -99,7 +99,38 @@ const ThirdPage = () => {
               </Col>
               <Col gap={28} align="center">
                 <Text
-                  label={'9. 흡연 여부를 선택해 주세요.'}
+                  label={'10. 한 달 기준 음주 횟수를 선택해 주세요.'}
+                  color={'Gray500'}
+                  typography={'NeoTitleM'}
+                  weight={400}
+                  size={18}
+                />
+                <Col gap={17} align="center">
+                  <Text
+                    label={`${drinkRange[0]} - ${drinkRange[1]} 회`}
+                    color={'Primary500'}
+                    typography={'LeferiBaseRegular'}
+                    weight={700}
+                    size={20}
+                  />
+                  <Col padding="15px">
+                    <RangeSlider
+                      value={drinkRange}
+                      onChange={value => {
+                        setPageState(prev => ({ ...prev, drinkRange: value }));
+                      }}
+                      min={0}
+                      max={25}
+                      markStep={5}
+                      step={1}
+                      maxMarkPostfix="~"
+                    />
+                  </Col>
+                </Col>
+              </Col>
+              <Col gap={28} align="center">
+                <Text
+                  label={'11. 흡연 여부를 선택해 주세요.'}
                   color={'Gray500'}
                   typography={'NeoTitleM'}
                   weight={400}
@@ -124,39 +155,6 @@ const ThirdPage = () => {
                     }
                     borderType="primary"
                   />
-                </Col>
-              </Col>
-              <Col gap={28} align="center">
-                <Text
-                  label={'10. 한 달 기준 음주 횟수를 선택해 주세요.'}
-                  color={'Gray500'}
-                  typography={'NeoTitleM'}
-                  weight={400}
-                  size={18}
-                />
-                {/* 슬라이더 수정 이후 gap 값 수정 */}
-                <Col gap={17} align="center">
-                  <Text
-                    label={`${drinkRange[0]} - ${drinkRange[1]} 회`}
-                    color={'Primary500'}
-                    typography={'LeferiBaseRegular'}
-                    weight={700}
-                    size={20}
-                  />
-                  {/* 슬라이더 수정 이후 패딩 값 수정*/}
-                  <Col padding="15px">
-                    <RangeSlider
-                      value={drinkRange}
-                      onChange={value => {
-                        setPageState(prev => ({ ...prev, drinkRange: value }));
-                      }}
-                      min={0}
-                      max={25}
-                      markStep={5}
-                      step={1}
-                      maxMarkPostfix="~"
-                    />
-                  </Col>
                 </Col>
               </Col>
             </Col>

--- a/src/pages/personal/myPreferTypeStep/SecondPage.tsx
+++ b/src/pages/personal/myPreferTypeStep/SecondPage.tsx
@@ -51,19 +51,50 @@ const SecondPage = () => {
         <Paddler top={36} right={20} bottom={24} left={20}>
           <Row>
             <Col gap={56}>
+              <Col gap={28} align={'center'}>
+                <Text
+                  label={
+                    '4. 선호하는 상대의 한 달 기준 \n' +
+                    '음주 횟수를 선택해 주세요'
+                  }
+                  color={'Gray500'}
+                  typography={'NeoTitleM'}
+                  weight={400}
+                  size={18}
+                />
+                <Col gap={32} align="center">
+                  <Text
+                    label={`${drinkRange[0]} - ${drinkRange[1]} 회`}
+                    color={'Primary500'}
+                    typography={'LeferiBaseRegular'}
+                    weight={700}
+                    size={20}
+                  />
+                  <RangeSlider
+                    value={drinkRange}
+                    onChange={value =>
+                      setPageState(prev => ({ ...prev, drinkRange: value }))
+                    }
+                    min={0}
+                    max={25}
+                    markStep={5}
+                    step={1}
+                    maxMarkPostfix="~"
+                  />
+                </Col>
+              </Col>
+
               <Col gap={28}>
                 <Col gap={12} align="center">
                   <Text
-                    label={'4. 매칭을 원하는 대학을 선택해 주세요'}
+                    label={'5. 매칭을 원하는 대학을 선택해 주세요'}
                     color={'Gray500'}
                     typography={'NeoTitleM'}
                     weight={400}
                     size={18}
                   />
                   <Text
-                    label={
-                      '복수 선택이 가능하며 무관한 경우 모두 선택해 주세요.'
-                    }
+                    label={'원하는 선택지를 모두 선택해 주세요.'}
                     color={'Gray400'}
                     typography={'GoThicBodyS'}
                     weight={400}
@@ -98,16 +129,14 @@ const SecondPage = () => {
               <Col gap={28}>
                 <Col gap={12} align="center">
                   <Text
-                    label={'5. 선호하는 상대의 종교를 선택해 주세요'}
+                    label={'6. 선호하는 상대의 종교를 선택해 주세요'}
                     color={'Gray500'}
                     typography={'NeoTitleM'}
                     weight={400}
                     size={18}
                   />
                   <Text
-                    label={
-                      '복수 선택이 가능하며 무관한 경우 모두 선택해 주세요.'
-                    }
+                    label={'원하는 선택지를 모두 선택해 주세요.'}
                     color={'Gray400'}
                     typography={'GoThicBodyS'}
                     weight={400}
@@ -163,23 +192,15 @@ const SecondPage = () => {
                   </Row>
                 </Col>
               </Col>
-              <Col gap={28}>
-                <Col align="center">
-                  <Text
-                    label={'6. 선호하는 상대의 흡연 여부를'}
-                    color={'Gray500'}
-                    typography={'NeoTitleM'}
-                    weight={400}
-                    size={18}
-                  />
-                  <Text
-                    label={'선택해 주세요'}
-                    color={'Gray500'}
-                    typography={'NeoTitleM'}
-                    weight={400}
-                    size={18}
-                  />
-                </Col>
+              <Col gap={28} align="center">
+                <Text
+                  align="center"
+                  label={'7. 선호하는 상대의 흡연 여부를 \n' + '선택해 주세요'}
+                  color={'Gray500'}
+                  typography={'NeoTitleM'}
+                  weight={400}
+                  size={18}
+                />
                 <Col gap={8}>
                   <RoundButton
                     status={smoking === '흡연' ? 'active' : 'inactive'}
@@ -213,46 +234,6 @@ const SecondPage = () => {
                       }))
                     }
                     borderType="primary"
-                  />
-                </Col>
-              </Col>
-
-              <Col gap={28}>
-                <Col align="center">
-                  <Text
-                    label={'7. 선호하는 상대의 한 달 기준'}
-                    color={'Gray500'}
-                    typography={'NeoTitleM'}
-                    weight={400}
-                    size={18}
-                  />
-                  <Text
-                    label={'음주 횟수를 선택해 주세요'}
-                    color={'Gray500'}
-                    typography={'NeoTitleM'}
-                    weight={400}
-                    size={18}
-                  />
-                </Col>
-                <Col gap={32} align="center">
-                  <Text
-                    label={`${drinkRange[0]} - ${drinkRange[1]} 회`}
-                    color={'Primary500'}
-                    typography={'LeferiBaseRegular'}
-                    weight={700}
-                    size={20}
-                  />
-                  {/* 슬라이더 수정 이후 패딩 값 수정*/}
-                  <RangeSlider
-                    value={drinkRange}
-                    onChange={value =>
-                      setPageState(prev => ({ ...prev, drinkRange: value }))
-                    }
-                    min={0}
-                    max={25}
-                    markStep={5}
-                    step={1}
-                    maxMarkPostfix="~"
                   />
                 </Col>
               </Col>


### PR DESCRIPTION
# RangeSlider가 들어간 Form 페이지에서 순서 수정

![image](https://github.com/uoslife/client-meeting-season4/assets/97388599/23157cfa-cf48-4b82-abb3-a7ecd26b0ebc) -> 2번으로 가기로 했습니다~ ![image](https://github.com/uoslife/client-meeting-season4/assets/97388599/ea3a270a-01c8-4c37-8803-3b6a52373526)
이외 질문 번호가 이상하게 걸려 있던 것도 고쳤습니다.

# ApplicationModal 수정

![image](https://github.com/uoslife/client-meeting-season4/assets/97388599/efb159e9-c7e9-49c3-933c-c34c0d1738ab)

- 이러한 이슈로 ApplicationModal(`src/components/modal/applicationModal/ApplicationModal.style.tsx`)에 약간의 수정을 가했습니다. @soeun2537 참고해주세요~

# 대학 선택 Flow 추가

- 신청 후 신청정보 확인, 매칭결과 확인을 위한 인증 페이지에 대학 선택 Flow가 빠져 있어서 추가하였습니다.

# For Reviewers

- 아래 페이지들은 하나하나 뜯어보며 리뷰하지 마시고, 다른 페이지로부터 복붙한 것이구나~ 하는것만 보고 넘어가셔도 됩니다.
- `src\pages\common\univVerificationStep\FirstPage.tsx` -> `src/pages/common/verifyForMatchingResultStep/FirstPage.tsx` , `src\pages\common\verifyForCheckAfterAleadyAppliedStep\FirstPage.tsx`
  - 대학 선택 페이지입니다.

- `src/pages/common/verifyForMatchingResultStep/FirstPage.tsx(이전 버전)` , `src\pages\common\verifyForCheckAfterAleadyAppliedStep\FirstPage.tsx(이전 버전)` -> `src/pages/common/verifyForMatchingResultStep/SecondPage.tsx` , `src\pages\common\verifyForCheckAfterAleadyAppliedStep\SecondPage.tsx`
  - 기존의 FirstPage가 대학 선택 페이지로 바뀜에 따라 기존의 내용물들을 SecondPage로 옮겨 두었습니다.