### PR TITLE
[M4FE-23] 로그인 전역값을 통한 로그인 여부 관리

### DIFF
--- a/src/models/auth/index.ts
+++ b/src/models/auth/index.ts
@@ -1,0 +1,4 @@
+import { atom } from 'jotai';
+
+export const isLoggedInAtom = atom(false);
+isLoggedInAtom.debugLabel = 'isLoggedIn';

--- a/src/pages/common/univVerificationStep/ThirdPage.tsx
+++ b/src/pages/common/univVerificationStep/ThirdPage.tsx
@@ -15,18 +15,17 @@ import { AuthAPI } from '~/api';
 import { SilentLogin } from '~/utils/silentLogin';
 
 const ThirdPage = () => {
-  const setIsPageFinished = useSetAtom(pageFinishAtom);
   const login = new SilentLogin();
   const storedUnivType = useAtomValue(
     commonDataAtoms.commonUnivVerificationStep.page1,
   ).univType;
   const pageValidity = useAtomValue(combinedValidatiesAtoms)
     .commonUnivVerificationStep.page3;
-  setIsPageFinished(pageValidity);
-
   const setPageState = useSetAtom(
     commonDataAtoms.commonUnivVerificationStep.page3,
   );
+  const setIsPageFinished = useSetAtom(pageFinishAtom);
+  setIsPageFinished(pageValidity);
 
   const { inputValue, handleInputChange } = useInput('');
   const {
@@ -71,7 +70,7 @@ const ThirdPage = () => {
   const handleTryValidate = async () => {
     if (inputValue) setTryValidate(true);
     await AuthAPI.getVerificationCode({
-      email: inputValue,
+      email: `${inputValue}@${storedUnivType === 'HUFS' ? 'hufs' : 'khu'}.ac.kr`,
       university: storedUnivType,
     });
   };

--- a/src/utils/silentLogin.ts
+++ b/src/utils/silentLogin.ts
@@ -1,19 +1,22 @@
 import { AuthAPI } from '~/api';
 import { AxiosResponse } from 'axios';
 import API from '~/api/core';
+import { useSetAtom } from 'jotai';
+import { isLoggedInAtom } from '~/models/auth';
 
 export class SilentLogin {
-  JWT_EXPIRY_TIME = 24 * 3600 * 1000; // 만료 시간 (24시간 밀리 초로 표현)
-  // JWT_EXPIRY_TIME = 5000; // 만료 시간 (24시간 밀리 초로 표현)
+  setIsLoggedIn = useSetAtom(isLoggedInAtom);
+  JWT_EXPIRY_TIME = 3600 * 1000; // 만료 시간 (1시간 밀리 초로 표현)
   onSilentRefresh = () => {
     AuthAPI.getRefreshToken().then(this.onLoginSuccess);
   };
 
   onLoginSuccess = (response: AxiosResponse) => {
     const { accessToken } = response.data;
+    this.setIsLoggedIn(true);
 
     API.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
 
-    setTimeout(this.onSilentRefresh, this.JWT_EXPIRY_TIME);
+    setTimeout(this.onSilentRefresh, this.JWT_EXPIRY_TIME - 60000);
   };
 }


### PR DESCRIPTION
# 로그인 전역값을 통한 로그인 여부 관리

## 개요
- 로그인 전역 atom을 추가했습니다.
- 랜딩페이지에서 silentRefresh에 대한 오류 처리를 진행했습니다.
- JWT 토큰의 시간을 1시간으로 설정했습니다.
- JWT 토큰 유효시간이 1분 남으면 자동으로 갱신하는 로직을 추가했습니다.