### PR TITLE
[M4FE-33] API error response invalid input toast 대응

### DIFF
--- a/src/api/core/index.ts
+++ b/src/api/core/index.ts
@@ -7,29 +7,42 @@ export const API = axios.create({
   baseURL: 'https://meeting.alpha.uoslife.com/',
 });
 
+interface IErrorResponseData {
+  code: string;
+  message: string;
+  status: number;
+}
+
+const handleAuthSilentRefresh = async (originRequest: AxiosError) => {
+  if (originRequest.response?.status === 401) {
+    await AuthAPI.getRefreshToken()
+      .then(res => {
+        API.defaults.headers.common.Authorization = `Bearer ${res.data.accessToken}`;
+        originRequest.config!.headers.Authorization = `Bearer ${res.data.accessToken}`;
+        return axios(originRequest.config!);
+      })
+      .catch(() => {
+        toast.error('다시 로그인해주세요!', {
+          duration: 2000,
+        });
+        setTimeout(
+          () => (window.location.href = '/common/univVerificationStep'),
+          1500,
+        );
+      });
+  }
+};
+
 API.interceptors.response.use(
   (res: AxiosResponse) => res,
-  async (error: AxiosError & { config: { retryCount: number } }) => {
-    const originRequest = error;
-    const statusCode = originRequest.response?.status;
-    if (statusCode === 401) {
-      await AuthAPI.getRefreshToken()
-        .then(res => {
-          API.defaults.headers.common.Authorization = `Bearer ${res.data.accessToken}`;
-          originRequest.config!.headers.Authorization = `Bearer ${res.data.accessToken}`;
-          return axios(originRequest.config!);
-        })
-        .catch(() => {
-          toast.error('다시 로그인해주세요!', {
-            duration: 2000,
-          });
-          setTimeout(
-            () => (window.location.href = '/common/univVerificationStep'),
-            1500,
-          );
-        });
+  async (error: AxiosError) => {
+    const { code } = error.response?.data as IErrorResponseData;
+    if (code === 'C01') {
+      toast.error('이전에 답하지 않은 질문은 없나 확인해주세요!', {
+        duration: 2000,
+      });
     }
-
+    await handleAuthSilentRefresh(error);
     return Promise.reject(error);
   },
 );

--- a/src/pages/group/member/myInformationStep/Step.tsx
+++ b/src/pages/group/member/myInformationStep/Step.tsx
@@ -2,50 +2,6 @@ import PageLayout from '~/components/layout/page/PageLayout';
 import { useFunnel } from '~/hooks/useFunnel';
 import FirstPage from './FirstPage';
 import SecondPage from './SecondPage';
-import { groupDataAtoms } from '~/models/group/data';
-import { useAtomValue } from 'jotai';
-import { MeetingAPI } from '~/api';
-
-const STUDENT_MAP = {
-  학부생: 'UNDERGRADUATE',
-  대학원생: 'POSTGRADUATE',
-  졸업생: 'GRADUATE',
-} as const;
-
-const useApi = () => {
-  const { name, age, kakaoId } = useAtomValue(
-    groupDataAtoms.groupMemberMyInformationStep.page1,
-  );
-
-  const { major, studentType } = useAtomValue(
-    groupDataAtoms.groupMemberMyInformationStep.page2,
-  );
-
-  const updateUser = () => {
-    const body = {
-      name,
-      age: Number(age.replace('~', '')),
-      kakaoTalkId: kakaoId,
-      department: major,
-      studentType: STUDENT_MAP[studentType!],
-      gender: null,
-      height: null,
-      phoneNumber: null,
-      drinkingMin: null,
-      drinkingMax: null,
-      interest: null,
-      mbti: null,
-      religion: null,
-      smoking: null,
-      spiritAnimal: null,
-    };
-
-    MeetingAPI.updateUser(body);
-  };
-
-  return { updateUser };
-};
-
 import { useAtomValue } from 'jotai';
 import { groupDataAtoms } from '~/models/group/data';
 import { MeetingAPI } from '~/api';


### PR DESCRIPTION
# API error response invalid input toast 대응

## 개요
- 렌더링 오류 해겨를 위해 3대3 팅원 개인정보에서 중복 코드를 제거했습니다.
- axios response interceptor를 활용해 API response에 error 중 invalid input 유형이 발생하면 toast 대응합니다.